### PR TITLE
Run ATH under Wine when on Mac

### DIFF
--- a/src/blab/ath.py
+++ b/src/blab/ath.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import meshio
 
+from sys import platform
 from blab.config import RadiatorConfig
 from blab.mesh_clean import (
     AREA_TOL,
@@ -82,8 +83,13 @@ def run_ath(
     config_path.write_text(config_text, encoding="utf-8")
     output_root = read_ath_output_root(ath_companion_config) or ath_exe.parent
 
+    ath_prefix = ""
+    if platform == "darwin":
+        # TODO: add check to see if wine is installed? 
+        ath_prefix = "wine"
+
     completed = subprocess.run(
-        [str(ath_exe), str(config_path)],
+        [ath_prefix, str(ath_exe), str(config_path)],
         cwd=ath_exe.parent,
         capture_output=True,
         text=True,


### PR DESCRIPTION
Adds a check to prefix the Wine command if running under MacOS.

I considered making this a larger change that checks the platform on main app startup and modifies a couple of settings based on the running platform, but this is technically all that's needed to get the whole app running under Mac in my experience. 

One specific example of a setting that could vary by platform is the default solver / enabled solvers. OpenCL support has been removed for Apple Silicon Macs, so setting the default solver to Beat Engine (CPU) and removing the OpenCL option from the list of solvers would create a slightly better user experience. 