### PR TITLE
Improve macOS support with HornLab integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ src/blab/solvers/julia_local/results/
 src/blab/solvers/julia_local/runs/
 src/blab/solvers/julia_local/test_meshes/staged_symmetry/
 LocalPreferences.toml
+
+# Machine-local Ath runtime config (per-machine OutputRootDir/MeshCmd paths; the
+# app regenerates it, so it must not be committed).
+ath/ath.cfg

--- a/ath/ath.cfg
+++ b/ath/ath.cfg
@@ -1,4 +1,0 @@
-
-OutputRootDir = "E:\AthGUI\boundary-lab\runs\ath_output"
-MeshCmd = "E:\AthGUI\boundary-lab\gmsh\gmsh-4.15.2-Windows64\gmsh.exe %f -"
-GnuplotPath = "C:\Program Files\gnuplot\bin\gnuplot"

--- a/src/blab/ath.py
+++ b/src/blab/ath.py
@@ -7,6 +7,8 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -36,11 +38,98 @@ DEFAULT_CLEAN_SUFFIX = "_clean"
 ATH_CFG_OUTPUT_ROOT_KEY = "OutputRootDir"
 ATH_CFG_MESH_CMD_KEY = "MeshCmd"
 SOLVING_SYM_RE = re.compile(r"\bSym\s*=\s*([A-Za-z]+)\b")
+MESH_QUADRANTS_RE = re.compile(r"^\s*Mesh\.Quadrants\s*=\s*([^;#\n]*)", re.IGNORECASE | re.MULTILINE)
+# ``Mesh.Quadrants`` names the covered quadrants of a symmetric model; the value
+# maps to the mirror axes needed to reconstruct the full model. Quarter meshes
+# (quadrant 1) mirror across X and Y, half meshes across a single axis, and full
+# meshes (1234) need no mirroring. Mirrors the HornLab mesher's own quadrant map.
+QUADRANTS_MIRROR_AXES = {"1": "xy", "12": "y", "14": "x", "1234": ""}
 WINE_PLATFORMS = {"linux", "darwin"}
 
 
 class AthCancelledError(RuntimeError):
     """Raised when an active Ath generation is cancelled by the user."""
+
+
+class HornlabWaveguideGenerationError(RuntimeError):
+    """Raised when the optional HornLab waveguide mesher fallback cannot generate a mesh."""
+
+
+class HornlabMesherRunner:
+    """Small cancellable subprocess wrapper for the optional HornLab mesher."""
+
+    def __init__(self) -> None:
+        self._process: subprocess.Popen[str] | None = None
+        self._cancel_requested = False
+
+    def run(self, config_path: Path, msh_path: Path, *, timeout_s: float | None = None) -> None:
+        self._cancel_requested = False
+        self._process = subprocess.Popen(
+            [sys.executable, "-c", _HORNLAB_MESHER_BUILD_SCRIPT, str(config_path), str(msh_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            stdout, stderr = self._process.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            self.stop()
+            raise
+        finally:
+            process = self._process
+            self._process = None
+
+        if self._cancel_requested:
+            raise AthCancelledError("HornLab mesh generation cancelled")
+
+        returncode = 0 if process is None else process.returncode
+        if returncode == 0:
+            return
+
+        completed = subprocess.CompletedProcess(
+            [sys.executable, "-c", _HORNLAB_MESHER_BUILD_SCRIPT, str(config_path), str(msh_path)],
+            returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        details = _subprocess_failure_details(completed)
+        if _hornlab_mesher_missing(stderr):
+            raise HornlabWaveguideGenerationError(
+                "HornLab waveguide mesher is not installed. Install hornlab-waveguide-mesher "
+                "or install Wine so Boundary Lab can run Ath.exe."
+            )
+        raise RuntimeError(details)
+
+    def stop(self) -> None:
+        self._cancel_requested = True
+        process = self._process
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5.0)
+
+
+_HORNLAB_MESHER_BUILD_SCRIPT = """
+import sys
+from pathlib import Path
+
+from hornlab_mesher import build_from_config, load_config
+
+config = load_config(Path(sys.argv[1]))
+# Boundary Lab treats every Ath-family mesh as millimetres (matching real
+# Ath/ABEC output), so request millimetre output rather than the mesher's
+# default metres. The solver then applies ATH_MESH_SCALE_FACTOR uniformly.
+mesh_section = config.get("mesh")
+if not isinstance(mesh_section, dict):
+    mesh_section = {}
+    config["mesh"] = mesh_section
+mesh_section["scale_to_metres"] = False
+build_from_config(config, Path(sys.argv[2]))
+""".strip()
 
 
 def _ath_process_command(ath_exe: Path, config_path: Path) -> list[str]:
@@ -188,6 +277,186 @@ def run_ath(
     )
 
 
+def _hornlab_mesher_missing(details: str) -> bool:
+    return "ModuleNotFoundError" in details and (
+        "No module named 'hornlab_mesher'" in details or 'No module named "hornlab_mesher"' in details
+    )
+
+
+def _subprocess_failure_details(completed: subprocess.CompletedProcess[str]) -> str:
+    output = completed.stderr.strip() or completed.stdout.strip()
+    if not output:
+        return f"process exited with code {completed.returncode}"
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    return lines[-1] if lines else output
+
+
+def hornlab_symmetry_axes_from_config(config_text: str) -> str:
+    """Return the mirror axes ("", "x", "y", or "xy") implied by ``Mesh.Quadrants``.
+
+    The HornLab mesher emits a reduced model when ``Mesh.Quadrants`` selects fewer
+    than all four quadrants. Boundary Lab reconstructs the full model by mirroring,
+    so this maps the quadrant coverage onto the axes that need mirroring.
+    """
+    match = MESH_QUADRANTS_RE.search(config_text)
+    if match is None:
+        return ""
+    digits = "".join(sorted({char for char in match.group(1) if char in "1234"}))
+    return QUADRANTS_MIRROR_AXES.get(digits, "")
+
+
+def _write_hornlab_solving_file(mesh_dir: Path, symmetry_axes: str) -> None:
+    """Record the mesh's mirror symmetry so mesh cleaning reconstructs the full model.
+
+    Real Ath drops a ``solving.txt`` next to the mesh declaring ``Sym=<axes>``;
+    :func:`clean_ath_mesh_output` reads it to mirror the reduced mesh back to the
+    full model. The HornLab mesher does not, so emit an equivalent file here.
+    """
+    if not symmetry_axes:
+        return
+    solving_path = mesh_dir / "solving.txt"
+    solving_path.write_text(
+        f"Control_Solver\n  Abscissa=log; Dim=3D; Sym={symmetry_axes}\n",
+        encoding="utf-8",
+    )
+
+
+def _build_hornlab_waveguide_mesh(
+    config_path: Path,
+    msh_path: Path,
+    *,
+    runner: HornlabMesherRunner | None = None,
+    timeout_s: float | None = None,
+) -> None:
+    (runner or HornlabMesherRunner()).run(config_path, msh_path, timeout_s=timeout_s)
+
+
+_MESHER_UNSUPPORTED_RE = re.compile(r"^\s*Throat\.Ext\.Length\s*=\s*([^;#\n]+)", re.IGNORECASE | re.MULTILINE)
+
+
+def _mesher_unsupported_reason(config_text: str) -> str | None:
+    """Return a reason when the HornLab mesher would silently mis-mesh ``config_text``.
+
+    ``Throat.Ext.Length`` (a throat extension tube) is the one Ath feature the mesher
+    gets geometrically wrong without raising: Ath prepends the tube and keeps the main
+    horn ``Length`` and mouth radius, but the mesher subtracts the extension from
+    ``Length``, shrinking the horn (16-32% mouth-radius error). Guarding here forces the
+    Ath fallback. ``Throat.Ext.Angle`` alone is fine.
+    """
+    match = _MESHER_UNSUPPORTED_RE.search(config_text)
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    if not value:
+        return None
+    try:
+        if float(value) == 0.0:
+            return None
+    except ValueError:
+        pass  # a non-numeric (expression) extension length -- assume non-zero
+    return "Throat.Ext.Length (throat extension tube) is not meshed correctly by the HornLab mesher; using Ath instead."
+
+
+def run_hornlab_waveguide(
+    *,
+    config_text: str,
+    run_root: Path,
+    case_name: str = "waveguide",
+    runner: HornlabMesherRunner | None = None,
+    timeout_s: float | None = None,
+) -> AthRunResult:
+    """Generate an Ath-compatible mesh with the optional HornLab waveguide mesher."""
+    reason = _mesher_unsupported_reason(config_text)
+    if reason is not None:
+        raise HornlabWaveguideGenerationError(reason)
+    run_root = Path(run_root)
+    output_dir = run_root / case_name
+    mesh_dir = output_dir / "ABEC_FreeStanding"
+    config_path = run_root / f"{case_name}.cfg"
+    msh_path = mesh_dir / f"{case_name}.msh"
+    run_root.mkdir(parents=True, exist_ok=True)
+    mesh_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(config_text, encoding="utf-8")
+
+    try:
+        _build_hornlab_waveguide_mesh(config_path, msh_path, runner=runner, timeout_s=timeout_s)
+    except AthCancelledError:
+        raise
+    except HornlabWaveguideGenerationError:
+        raise
+    except Exception as exc:
+        raise HornlabWaveguideGenerationError(
+            "HornLab waveguide mesher fallback failed. It currently supports OSSE/R-OSSE "
+            "waveguide configs with ABEC-compatible physical tags; unsupported Ath geometry "
+            f"still requires Wine/Ath. Details: {exc}"
+        ) from exc
+
+    _write_hornlab_solving_file(mesh_dir, hornlab_symmetry_axes_from_config(config_text))
+
+    # The mesher was asked for millimetre output (see the build script above),
+    # matching real Ath/ABEC, so discover_ath_output's millimetre scale applies.
+    return discover_ath_output(
+        run_root=run_root,
+        case_name=case_name,
+        config_path=config_path,
+    )
+
+
+def generate_waveguide_mesh(
+    *,
+    ath_exe: Path,
+    config_text: str,
+    run_root: Path,
+    case_name: str = "waveguide",
+    runner: AthProcessRunner | None = None,
+    mesher_runner: HornlabMesherRunner | None = None,
+    timeout_s: float | None = None,
+    on_status: Callable[[str], None] | None = None,
+) -> AthRunResult:
+    """Generate a waveguide mesh, preferring the native HornLab mesher.
+
+    The HornLab waveguide mesher is the fast path: it is native Python (no Wine, no
+    Rosetta, no gmsh.exe subprocess) and covers OSSE/R-OSSE-style waveguides. When it
+    cannot handle a geometry -- or is not installed -- it raises
+    :class:`HornlabWaveguideGenerationError`, and we fall back to the full Ath toolchain
+    (Ath.exe, via Wine on macOS/Linux), which supports every Ath geometry but is slower
+    and needs Wine off Windows.
+    """
+
+    def _status(message: str) -> None:
+        if on_status is not None:
+            on_status(message)
+
+    try:
+        _status("Generating mesh (HornLab waveguide mesher)...")
+        return run_hornlab_waveguide(
+            config_text=config_text,
+            run_root=run_root,
+            case_name=case_name,
+            runner=mesher_runner,
+            timeout_s=timeout_s,
+        )
+    except AthCancelledError:
+        raise
+    except HornlabWaveguideGenerationError as mesher_exc:
+        _status("HornLab mesher unavailable for this geometry; running Ath...")
+        runner = runner or AthProcessRunner()
+        try:
+            return runner.run(
+                ath_exe=ath_exe,
+                config_text=config_text,
+                run_root=run_root,
+                case_name=case_name,
+                timeout_s=timeout_s,
+            )
+        except AthCancelledError:
+            raise
+        except (RuntimeError, FileNotFoundError) as ath_exc:
+            raise RuntimeError(
+                f"HornLab mesher could not generate this geometry ({mesher_exc}); Ath fallback also failed: {ath_exc}"
+            ) from ath_exc
+
+
 def read_ath_output_root(ath_cfg_path: Path) -> Path | None:
     with ath_cfg_path.open("r", encoding="utf-8", errors="replace") as cfg_file:
         for raw_line in cfg_file:
@@ -238,9 +507,53 @@ def write_ath_output_root(ath_cfg_path: Path, output_root: Path) -> Path:
     return output_root
 
 
+def _space_free_stage_bases() -> list[Path]:
+    """Candidate space-free base directories for staging a gmsh symlink."""
+    bases = [Path.home() / ".cache" / "blab", Path(tempfile.gettempdir()) / "blab"]
+    return [base for base in bases if " " not in str(base)]
+
+
+def _stage_gmsh_without_spaces(gmsh_exe: Path) -> Path:
+    """Return a gmsh executable path with no spaces in it.
+
+    Ath runs its ``MeshCmd`` through ``cmd`` (native or Wine's), which splits the
+    command on spaces, and Ath's config parser strips quotes -- so a space anywhere in
+    the gmsh path cannot be escaped and meshing fails. This bites on macOS whenever the
+    project lives under a directory such as "boundary lab". When the resolved path has a
+    space, expose the gmsh directory at a space-free symlink and return the executable
+    inside it; otherwise return the path unchanged.
+    """
+    if " " not in str(gmsh_exe):
+        return gmsh_exe
+    gmsh_dir = gmsh_exe.parent
+    for base in _space_free_stage_bases():
+        link_dir = base / "gmsh"
+        try:
+            base.mkdir(parents=True, exist_ok=True)
+            if link_dir.is_symlink():
+                if Path(os.readlink(link_dir)) != gmsh_dir:
+                    link_dir.unlink()
+                    link_dir.symlink_to(gmsh_dir, target_is_directory=True)
+            elif link_dir.exists():
+                continue  # don't clobber a real directory squatting the path
+            else:
+                link_dir.symlink_to(gmsh_dir, target_is_directory=True)
+            staged = link_dir / gmsh_exe.name
+            if staged.exists() and " " not in str(staged):
+                return staged
+        except OSError:
+            continue
+    return gmsh_exe
+
+
 def write_ath_gmsh_path(ath_cfg_path: Path, gmsh_exe_path: Path) -> Path:
-    """Ensure ath.cfg points Ath's MeshCmd at an absolute Gmsh executable."""
-    gmsh_exe_path = gmsh_exe_path.resolve()
+    """Point ath.cfg's MeshCmd at an absolute, space-free Gmsh executable.
+
+    Ath cannot handle a space in the gmsh path (see
+    :func:`_stage_gmsh_without_spaces`), so when the bundled gmsh lives under a spaced
+    directory we point MeshCmd at a space-free symlink instead.
+    """
+    gmsh_exe_path = _stage_gmsh_without_spaces(gmsh_exe_path.resolve())
     _write_ath_cfg_value(ath_cfg_path, ATH_CFG_MESH_CMD_KEY, f"{gmsh_exe_path} %f -")
     return gmsh_exe_path
 
@@ -328,7 +641,30 @@ def read_surface_physical_names(msh_path: Path) -> dict[str, int]:
             name = name_text.strip().strip('"')
             surface_names[name] = int(tag_text)
 
-    return surface_names
+    return surface_names or _read_surface_physical_names_from_meshio(msh_path)
+
+
+def _read_surface_physical_names_from_meshio(msh_path: Path) -> dict[str, int]:
+    mesh = meshio.read(msh_path)
+    names_by_tag = {}
+    for name, value in mesh.field_data.items():
+        try:
+            tag = int(value[0])
+            dimension = int(value[1])
+        except (IndexError, TypeError, ValueError):
+            continue
+        if dimension == 2:
+            names_by_tag[tag] = str(name)
+
+    surface_tags = set()
+    for tri_key in ("triangle", "triangle3"):
+        if tri_key not in mesh.cells_dict:
+            continue
+        for data_name, by_cell_type in mesh.cell_data_dict.items():
+            if data_name == "gmsh:physical" and tri_key in by_cell_type:
+                surface_tags.update(int(tag) for tag in by_cell_type[tri_key])
+
+    return {names_by_tag.get(tag, f"Tag {tag}"): tag for tag in sorted(surface_tags)}
 
 
 def detect_ath_radiators(msh_path: Path) -> tuple[RadiatorConfig, ...]:

--- a/src/blab/ath_config.py
+++ b/src/blab/ath_config.py
@@ -1,0 +1,283 @@
+"""Small parser for Ath/ABEC solve metadata embedded in .cfg files."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AthPolarSettings:
+    name: str
+    distance_m: float | None = None
+    inclination_deg: float | None = None
+    map_min_angle_deg: float | None = None
+    map_max_angle_deg: float | None = None
+    map_sample_count: int | None = None
+    norm_angle_deg: float | None = None
+
+    @property
+    def map_step_deg(self) -> float | None:
+        if (
+            self.map_min_angle_deg is None
+            or self.map_max_angle_deg is None
+            or self.map_sample_count is None
+            or self.map_sample_count < 2
+        ):
+            return None
+        return abs(self.map_max_angle_deg - self.map_min_angle_deg) / float(self.map_sample_count - 1)
+
+
+@dataclass(frozen=True)
+class AthSolveSettings:
+    freq_min_hz: float | None = None
+    freq_max_hz: float | None = None
+    freq_count: int | None = None
+    polar_min_angle_deg: float | None = None
+    polar_max_angle_deg: float | None = None
+    polar_step_deg: float | None = None
+    polar_distance_m: float | None = None
+    horizontal_norm_angle_deg: float | None = None
+    vertical_norm_angle_deg: float | None = None
+
+
+BARE_MESH_MODES = {"bare", "inner", "open"}
+ENCLOSED_MESH_MODES = {"enclosure", "enclosed"}
+FREESTANDING_MESH_MODES = {"free-standing", "freestanding", "free"}
+INFINITE_BAFFLE_MESH_MODES = {"infinite-baffle", "infinitebaffle", "ib", "baffle"}
+_ASSIGNMENT_RE = re.compile(r"^\s*(?P<key>[A-Za-z0-9_.:]+)\s*=\s*(?P<value>.*?)\s*$")
+_POLAR_BLOCK_RE = re.compile(r"^\s*ABEC\.Polars:(?P<name>[^=\s]+)\s*=\s*\{\s*$", re.IGNORECASE)
+_NUMBER_RE = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+
+
+def parse_ath_solve_settings(config_text: str) -> AthSolveSettings:
+    top_level: dict[str, str] = {}
+    polar_blocks = _parse_polar_blocks(config_text)
+
+    current_polar: str | None = None
+    for raw_line in config_text.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+        if current_polar is not None:
+            if line.startswith("}"):
+                current_polar = None
+            continue
+        block_match = _POLAR_BLOCK_RE.match(line)
+        if block_match:
+            current_polar = block_match.group("name")
+            continue
+        assignment = _ASSIGNMENT_RE.match(line)
+        if assignment:
+            top_level[assignment.group("key").strip().lower()] = assignment.group("value").strip()
+
+    horizontal = _select_horizontal_polar(polar_blocks)
+    vertical = _select_vertical_polar(polar_blocks)
+    range_source = _first_polar_with_range(horizontal, vertical, *polar_blocks)
+    distance_source = _first_polar_with_distance(horizontal, vertical, *polar_blocks)
+
+    return AthSolveSettings(
+        freq_min_hz=_parse_float(top_level.get("abec.f1")),
+        freq_max_hz=_parse_float(top_level.get("abec.f2")),
+        freq_count=_parse_positive_int(top_level.get("abec.numfrequencies")),
+        polar_min_angle_deg=None if range_source is None else range_source.map_min_angle_deg,
+        polar_max_angle_deg=None if range_source is None else range_source.map_max_angle_deg,
+        polar_step_deg=None if range_source is None else range_source.map_step_deg,
+        polar_distance_m=None if distance_source is None else distance_source.distance_m,
+        horizontal_norm_angle_deg=None if horizontal is None else horizontal.norm_angle_deg,
+        vertical_norm_angle_deg=None if vertical is None else vertical.norm_angle_deg,
+    )
+
+
+def native_check_open_edges_for_ath_config(config_text: str) -> bool:
+    """Return whether native symmetric solves should enforce open-edge checks.
+
+    HornLab Metal needs strict open-edge validation for closed reduced meshes.
+    Only bare/open waveguide modes have a real mouth rim off the symmetry planes,
+    so those are the only Ath-family configs that opt out.
+    """
+    return _parse_mesh_mode(config_text) != "bare"
+
+
+def _parse_polar_blocks(config_text: str) -> tuple[AthPolarSettings, ...]:
+    blocks: list[AthPolarSettings] = []
+    current_name: str | None = None
+    current_values: dict[str, str] = {}
+
+    for raw_line in config_text.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+        if current_name is None:
+            block_match = _POLAR_BLOCK_RE.match(line)
+            if block_match:
+                current_name = block_match.group("name").strip()
+                current_values = {}
+            continue
+        if line.startswith("}"):
+            blocks.append(_polar_settings_from_values(current_name, current_values))
+            current_name = None
+            current_values = {}
+            continue
+        assignment = _ASSIGNMENT_RE.match(line)
+        if assignment:
+            current_values[assignment.group("key").strip().lower()] = assignment.group("value").strip()
+
+    return tuple(blocks)
+
+
+def _parse_mesh_mode(config_text: str) -> str:
+    top_level = _parse_top_level_assignments(config_text)
+    raw_mode = _normalized_mode_value(_first_present(top_level, "mode", "mesh.mode"))
+    if raw_mode in BARE_MESH_MODES:
+        return "bare"
+    if raw_mode in ENCLOSED_MESH_MODES or _positive_depth_present(top_level):
+        return "enclosure"
+    if raw_mode in INFINITE_BAFFLE_MESH_MODES:
+        return "infinite-baffle"
+    if raw_mode in FREESTANDING_MESH_MODES:
+        return "freestanding"
+
+    sim_type = _parse_positive_int(_first_present(top_level, "abec.simtype", "simtype", "sim_type", "mesh.simtype"))
+    if sim_type == 1:
+        return "infinite-baffle"
+    return "freestanding"
+
+
+def _parse_top_level_assignments(config_text: str) -> dict[str, str]:
+    top_level: dict[str, str] = {}
+    current_polar: str | None = None
+    for raw_line in config_text.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+        if current_polar is not None:
+            if line.startswith("}"):
+                current_polar = None
+            continue
+        block_match = _POLAR_BLOCK_RE.match(line)
+        if block_match:
+            current_polar = block_match.group("name")
+            continue
+        assignment = _ASSIGNMENT_RE.match(line)
+        if assignment:
+            top_level[assignment.group("key").strip().lower()] = assignment.group("value").strip()
+    return top_level
+
+
+def _first_present(values: dict[str, str], *keys: str) -> str | None:
+    for key in keys:
+        if key in values:
+            return values[key]
+    return None
+
+
+def _normalized_mode_value(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.strip().strip('"').strip("'").lower().replace("_", "-")
+
+
+def _positive_depth_present(values: dict[str, str]) -> bool:
+    for key in ("enclosure.depth", "enclosure.depth_mm", "mesh.depth", "mesh.depth_mm", "encdepth", "depth_mm"):
+        depth = _parse_float(values.get(key))
+        if depth is not None and depth > 0.0:
+            return True
+    return False
+
+
+def _polar_settings_from_values(name: str, values: dict[str, str]) -> AthPolarSettings:
+    map_min, map_max, map_count = _parse_map_angle_range(values.get("mapanglerange"))
+    return AthPolarSettings(
+        name=name,
+        distance_m=_parse_float(values.get("distance")),
+        inclination_deg=_parse_float(values.get("inclination")),
+        map_min_angle_deg=map_min,
+        map_max_angle_deg=map_max,
+        map_sample_count=map_count,
+        norm_angle_deg=_parse_float(values.get("normangle")),
+    )
+
+
+def _select_horizontal_polar(polars: tuple[AthPolarSettings, ...]) -> AthPolarSettings | None:
+    named = _first_matching_polar_name(polars, {"h", "hor", "horizontal", "splh", "spl_h"})
+    if named is not None:
+        return named
+    for polar in polars:
+        if polar.inclination_deg is None or abs(polar.inclination_deg) < 1e-6:
+            return polar
+    return polars[0] if polars else None
+
+
+def _select_vertical_polar(polars: tuple[AthPolarSettings, ...]) -> AthPolarSettings | None:
+    named = _first_matching_polar_name(polars, {"v", "vert", "vertical", "splv", "spl_v"})
+    if named is not None:
+        return named
+    for polar in polars:
+        if polar.inclination_deg is not None and abs(polar.inclination_deg - 90.0) < 1e-6:
+            return polar
+    return _select_horizontal_polar(polars)
+
+
+def _first_matching_polar_name(
+    polars: tuple[AthPolarSettings, ...],
+    aliases: set[str],
+) -> AthPolarSettings | None:
+    for polar in polars:
+        normalized = _normalized_polar_name(polar.name)
+        if normalized in aliases:
+            return polar
+    return None
+
+
+def _first_polar_with_range(*polars: AthPolarSettings | None) -> AthPolarSettings | None:
+    for polar in polars:
+        if polar is not None and polar.map_step_deg is not None:
+            return polar
+    return None
+
+
+def _first_polar_with_distance(*polars: AthPolarSettings | None) -> AthPolarSettings | None:
+    for polar in polars:
+        if polar is not None and polar.distance_m is not None:
+            return polar
+    return None
+
+
+def _parse_map_angle_range(value: str | None) -> tuple[float | None, float | None, int | None]:
+    if value is None:
+        return None, None, None
+    parts = [part.strip() for part in value.split(",")]
+    if len(parts) < 3:
+        return None, None, None
+    start = _parse_float(parts[0])
+    stop = _parse_float(parts[1])
+    count = _parse_positive_int(parts[2])
+    if start is None or stop is None or count is None:
+        return None, None, None
+    return min(start, stop), max(start, stop), count
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    match = _NUMBER_RE.search(value.strip().strip('"'))
+    if match is None:
+        return None
+    return float(match.group(0))
+
+
+def _parse_positive_int(value: str | None) -> int | None:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return None
+    rounded = int(round(parsed))
+    return rounded if rounded > 0 else None
+
+
+def _strip_comment(line: str) -> str:
+    return line.split(";", 1)[0]
+
+
+def _normalized_polar_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", name.strip().lower())

--- a/src/blab/config.py
+++ b/src/blab/config.py
@@ -88,6 +88,13 @@ class SimulationConfig:
     spherical_sampling_enabled: bool = False
     spherical_sampling_points: int = 6000
     symmetry: str = "off"
+    # When a mirror-reduced (symmetric) mesh is solved, the Metal backend
+    # requires every open boundary edge to lie on a symmetry plane unless this is
+    # False. An open-mouth horn's mouth rim is a real free edge off the planes,
+    # so reduced-symmetry horn solves must opt out. Only consulted when a
+    # symmetry plane is active (symmetry != "off"); ignored by backends without
+    # native symmetry. See start_solve, which derives it from the symmetry mode.
+    native_check_open_edges: bool = True
     output_npz: str = str(SOLVER_OUTPUT_NPZ)
 
     def __post_init__(self) -> None:

--- a/src/blab/postprocess.py
+++ b/src/blab/postprocess.py
@@ -19,6 +19,8 @@ from scipy.interpolate import RegularGridInterpolator
 
 from blab.defaults import FORMATTED_OUTPUT_NPZ, SOLVER_OUTPUT_NPZ
 
+MIN_USEFUL_DB_SPAN = 6.0
+
 
 @dataclass
 class PrepConfig:
@@ -276,13 +278,16 @@ def prepare_visualization_data_from_arrays(
     horizontal = _fractional_octave_smooth(horizontal, freq_hz, cfg.octave_smoothing)
     vertical = _fractional_octave_smooth(vertical, freq_hz, cfg.octave_smoothing)
     clip_min_db, clip_max_db = _resolve_db_span(horizontal, vertical, cfg)
-    horizontal = np.clip(horizontal, clip_min_db, clip_max_db)
-    vertical = np.clip(vertical, clip_min_db, clip_max_db)
+    polar_clip_min_db, polar_clip_max_db = _resolve_polar_db_span(horizontal, vertical, cfg)
+    horizontal_clipped = np.clip(horizontal, polar_clip_min_db, polar_clip_max_db)
+    vertical_clipped = np.clip(vertical, polar_clip_min_db, polar_clip_max_db)
+    horizontal_isobar = np.clip(horizontal, clip_min_db, clip_max_db)
+    vertical_isobar = np.clip(vertical, clip_min_db, clip_max_db)
 
     isobar_angles, isobar_freqs, horizontal_interp = _interpolate_isobar_heatmap(
         base_angles_deg,
         freq_hz,
-        horizontal,
+        horizontal_isobar,
         cfg.angle_samples,
         cfg.freq_samples,
         clip_min_db,
@@ -290,7 +295,7 @@ def prepare_visualization_data_from_arrays(
     _, _, vertical_interp = _interpolate_isobar_heatmap(
         base_angles_deg,
         freq_hz,
-        vertical,
+        vertical_isobar,
         cfg.angle_samples,
         cfg.freq_samples,
         clip_min_db,
@@ -306,8 +311,8 @@ def prepare_visualization_data_from_arrays(
         "polar_angle_deg": base_angles_deg,
         "horizontal_spl_db": raw_horizontal.astype(np.float32, copy=False),
         "vertical_spl_db": raw_vertical.astype(np.float32, copy=False),
-        "horizontal_spl_norm_db": horizontal.T.astype(np.float32, copy=False),
-        "vertical_spl_norm_db": vertical.T.astype(np.float32, copy=False),
+        "horizontal_spl_norm_db": horizontal_clipped.T.astype(np.float32, copy=False),
+        "vertical_spl_norm_db": vertical_clipped.T.astype(np.float32, copy=False),
         "isobar_angle_deg": isobar_angles.astype(np.float32, copy=False),
         "isobar_freq_hz": isobar_freqs.astype(np.float32, copy=False),
         "horizontal_isobar_db": horizontal_interp,
@@ -327,18 +332,65 @@ def prepare_visualization_data_from_arrays(
 
 
 def _resolve_db_span(horizontal: np.ndarray, vertical: np.ndarray, cfg: PrepConfig) -> tuple[float, float]:
+    combined = np.concatenate([horizontal.ravel(), vertical.ravel()])
+    finite = combined[np.isfinite(combined)]
+
     if not cfg.auto_db_span:
+        min_db = float(cfg.min_db)
+        max_db = float(cfg.max_db)
+        if max_db <= min_db:
+            max_db = min_db + 1.0
+        if finite.size == 0:
+            return min_db, max_db
+
+        finite_min = float(np.min(finite))
+        finite_max = float(np.max(finite))
+        if finite_max < min_db or finite_min > max_db:
+            return _auto_db_span_from_finite(finite, min_db, max_db)
+        clipped_min = max(finite_min, min_db)
+        clipped_max = min(finite_max, max_db)
+        if clipped_max > clipped_min and clipped_max - clipped_min < MIN_USEFUL_DB_SPAN:
+            return _auto_db_span_from_finite(finite, min_db, max_db)
+        return min_db, max_db
+
+    if finite.size == 0:
         return float(cfg.min_db), float(cfg.max_db)
+
+    return _auto_db_span_from_finite(finite, float(cfg.min_db), float(cfg.max_db))
+
+
+def _resolve_polar_db_span(horizontal: np.ndarray, vertical: np.ndarray, cfg: PrepConfig) -> tuple[float, float]:
+    if cfg.auto_db_span:
+        return _resolve_db_span(horizontal, vertical, cfg)
+
+    min_db = float(cfg.min_db)
+    max_db = float(cfg.max_db)
+    if max_db <= min_db:
+        max_db = min_db + 1.0
 
     combined = np.concatenate([horizontal.ravel(), vertical.ravel()])
     finite = combined[np.isfinite(combined)]
     if finite.size == 0:
-        return float(cfg.min_db), float(cfg.max_db)
+        return min_db, max_db
 
+    finite_min = float(np.min(finite))
+    finite_max = float(np.max(finite))
+    if finite_max < min_db or finite_min > max_db:
+        return _auto_db_span_from_finite(finite, min_db, max_db)
+    return min_db, max_db
+
+
+def _auto_db_span_from_finite(finite: np.ndarray, fallback_min_db: float, fallback_max_db: float) -> tuple[float, float]:
     min_db = float(np.floor(np.min(finite)))
     max_db = float(np.ceil(np.max(finite)))
     if np.isclose(min_db, max_db):
         max_db = min_db + 1.0
+    if max_db <= min_db:
+        return fallback_min_db, fallback_max_db if fallback_max_db > fallback_min_db else fallback_min_db + 1.0
+    if max_db - min_db < MIN_USEFUL_DB_SPAN:
+        if float(np.max(finite)) <= fallback_max_db <= max_db + MIN_USEFUL_DB_SPAN:
+            max_db = fallback_max_db
+        min_db = max_db - MIN_USEFUL_DB_SPAN
     return min_db, max_db
 
 

--- a/src/blab/solvers/registry.py
+++ b/src/blab/solvers/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Callable
 
 from blab.solvers.base import SolverBackend, SolverCapabilities
@@ -16,6 +17,32 @@ class SolverBackendInfo:
     factory: Callable[..., SolverBackend] | None = None
     available: bool = True
     description: str = ""
+
+
+@lru_cache(maxsize=1)
+def _hornlab_metal_probe() -> tuple[bool, SolverCapabilities]:
+    """Probe the optional Metal backend once, returning ``(available, capabilities)``.
+
+    Cached so registry construction instantiates the backend a single time rather
+    than once per accessor. When unavailable, the capabilities are a placeholder
+    (``available`` is False, so the flags are never consulted) instead of a
+    hand-maintained mirror of the adapter that would silently drift.
+    """
+    try:
+        from hornlab_metal_bem.boundary_lab import create_backend as create_hornlab_backend
+
+        backend = create_hornlab_backend()
+        return bool(backend.supports()), backend.capabilities
+    except Exception:
+        return False, SolverCapabilities()
+
+
+def _hornlab_metal_capabilities() -> SolverCapabilities:
+    return _hornlab_metal_probe()[1]
+
+
+def _hornlab_metal_available() -> bool:
+    return _hornlab_metal_probe()[0]
 
 
 _BACKENDS: dict[str, SolverBackendInfo] = {
@@ -80,6 +107,14 @@ _BACKENDS: dict[str, SolverBackendInfo] = {
         factory=lambda **_kwargs: _create_bempp_local_backend(),
         description="Run the bundled bempp-cl OpenCL CPU solver in the GUI process.",
     ),
+    "hornlab_metal": SolverBackendInfo(
+        backend_id="hornlab_metal",
+        label="HornLab Metal BEM",
+        capabilities=_hornlab_metal_capabilities(),
+        factory=lambda **kwargs: _create_hornlab_metal_backend(**kwargs),
+        available=_hornlab_metal_available(),
+        description="Run the optional HornLab Apple Metal solver backend on Apple Silicon macOS.",
+    ),
 }
 
 
@@ -125,6 +160,10 @@ def normalize_backend_id(backend_id: str) -> str:
         "rocm": "beat_rocm",
         "amd": "beat_rocm",
         "amdgpu": "beat_rocm",
+        "hornlab": "hornlab_metal",
+        "hornlab_metal": "hornlab_metal",
+        "metal": "hornlab_metal",
+        "apple_metal": "hornlab_metal",
     }
     return aliases.get(text, text or "local")
 
@@ -141,6 +180,12 @@ def _create_bempp_local_backend() -> SolverBackend:
 
 def _create_bempp_server_backend(*, server_url: str = "http://127.0.0.1:8765", **_kwargs: Any) -> SolverBackend:
     return _create_http_server_backend(server_url=server_url)
+
+
+def _create_hornlab_metal_backend(**_kwargs: Any) -> SolverBackend:
+    from hornlab_metal_bem.boundary_lab import create_backend as create_hornlab_backend
+
+    return create_hornlab_backend()
 
 
 def _create_http_server_backend(*, server_url: str = "http://127.0.0.1:8765", **_kwargs: Any) -> SolverBackend:

--- a/src/blab/ui/ath_worker.py
+++ b/src/blab/ui/ath_worker.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 from PySide6.QtCore import QObject, Signal, Slot
 
-from blab.ath import AthCancelledError, AthProcessRunner, clean_ath_mesh_output
+from blab.ath import (
+    AthCancelledError,
+    AthProcessRunner,
+    HornlabMesherRunner,
+    clean_ath_mesh_output,
+    generate_waveguide_mesh,
+)
 
 
 class AthGenerationWorker(QObject):
@@ -30,17 +36,23 @@ class AthGenerationWorker(QObject):
         self.run_root = run_root
         self.case_name = case_name
         self._runner = AthProcessRunner()
+        self._mesher_runner = HornlabMesherRunner()
         self._stop = False
 
     @Slot()
     def run(self) -> None:
         try:
-            self.status.emit("Running Ath...")
-            raw_result = self._runner.run(
+            # Prefer the fast native HornLab mesher; fall back to Ath (Ath.exe via
+            # Wine on macOS/Linux) for geometries the mesher can't handle. The runner
+            # is threaded through so cancellation (stop()) still reaches an Ath run.
+            raw_result = generate_waveguide_mesh(
                 ath_exe=self.ath_exe,
                 config_text=self.config_text,
                 run_root=self.run_root,
                 case_name=self.case_name,
+                runner=self._runner,
+                mesher_runner=self._mesher_runner,
+                on_status=self.status.emit,
             )
             if self._stop:
                 self.cancelled.emit()
@@ -64,5 +76,6 @@ class AthGenerationWorker(QObject):
     @Slot()
     def stop(self) -> None:
         self._stop = True
-        self.status.emit("Stopping Ath generation...")
+        self.status.emit("Stopping mesh generation...")
+        self._mesher_runner.stop()
         self._runner.stop()

--- a/src/blab/ui/dialogs.py
+++ b/src/blab/ui/dialogs.py
@@ -641,6 +641,8 @@ class MeshConfigDialog(QDialog):
         scale_spin.setDecimals(6)
         scale_spin.setSingleStep(0.001)
         scale_spin.setValue(float(mesh.scale_factor))
+        if mesh.locked:
+            scale_spin.setEnabled(False)
         self.table.setCellWidget(row, 3, scale_spin)
         self.scale_widgets.append(scale_spin)
 

--- a/src/blab/ui/drag_drop.py
+++ b/src/blab/ui/drag_drop.py
@@ -7,6 +7,16 @@ from pathlib import Path
 
 def local_drop_paths(event) -> list[Path]:
     mime_data = event.mimeData()
-    if not mime_data.hasUrls():
-        return []
-    return [Path(url.toLocalFile()) for url in mime_data.urls() if url.isLocalFile()]
+    paths = [Path(url.toLocalFile()) for url in mime_data.urls() if url.isLocalFile()] if mime_data.hasUrls() else []
+    if paths or not mime_data.hasText():
+        return paths
+
+    text_paths = []
+    for line in mime_data.text().splitlines():
+        text = line.strip().strip("'\"")
+        if not text:
+            continue
+        path = Path(text).expanduser()
+        if path.exists():
+            text_paths.append(path)
+    return text_paths

--- a/src/blab/ui/main_window.py
+++ b/src/blab/ui/main_window.py
@@ -40,11 +40,13 @@ from blab.ath import (
     AthRunResult,
     clean_ath_reduced_mesh_output,
     detect_ath_radiators,
+    discover_ath_output,
     find_physical_tag_by_name,
     read_surface_physical_names,
     write_ath_gmsh_path,
     write_ath_output_root,
 )
+from blab.ath_config import AthSolveSettings, native_check_open_edges_for_ath_config, parse_ath_solve_settings
 from blab.config import ChannelConfig, MeshConfig, RadiatorConfig, SimulationConfig
 from blab.exporting import export_plot_png, export_polar_text_files
 from blab.live import (
@@ -69,6 +71,7 @@ from blab.ui.dialogs import (
     PreferencesDialog,
     SourceConfigDialog,
 )
+from blab.ui.drag_drop import local_drop_paths
 from blab.ui.main_window_widgets import (
     AthScriptEditor,
     DockTitleBar,
@@ -108,6 +111,7 @@ from blab.ui.project_state import (
     AthScriptState,
     default_scripts,
     new_script,
+    normalize_ath_mesh_scale,
     replace_script,
     script_to_payload,
     scripts_from_payload,
@@ -165,16 +169,37 @@ CLEAR_CONTOURS_DARK_ICON = APP_ROOT / "assets" / "clearcontours_dark.ico"
 CLEAR_CONTOURS_LIGHT_ICON = APP_ROOT / "assets" / "clearcontours_light.ico"
 ADD_SCRIPT_TAB_LABEL = "+"
 DEFAULT_DOCK_STATE_B64 = (
-    "AAAA/wAAAAD9AAAAAQAAAAAAAAduAAADdvwCAAAAAfwAAAAAAAADdgAAAG4A/////AEAAAAG+wAAAB4AYQB0AGgAXwBl"
-    "AGQAaQB0AG8AcgBfAGQAbwBjAGsBAAAAAAAAAdsAAACFAP////wAAAHfAAADRQAAAGoA/////AIAAAAC+wAAACIAbQBl"
-    "AHMAaABfAHAAcgBlAHYAaQBlAHcAXwBkAG8AYwBrAQAAAAAAAAN2AAAANAD////7AAAAHABzAHAAaQBuAG8AcgBhAG0A"
-    "YQBfAGQAbwBjAGsIAAAB4AAAAZYAAAAiAP////sAAAAUAHAAbABvAHQAcwBfAGQAbwBjAGsBAAAE9QAAAnkAAAAAAAAA"
-    "APwAAAUoAAACRgAAAHsA/////AIAAAAC+wAAACwAaABvAHIAaQB6AG8AbgB0AGEAbABfAGkAcwBvAGIAYQByAF8AZABv"
-    "AGMAawEAAAAAAAABugAAACIA////+wAAACgAdgBlAHIAdABpAGMAYQBsAF8AaQBzAG8AYgBhAHIAXwBkAG8AYwBrAQAA"
-    "Ab4AAAG4AAAAIgD////7AAAALgBhAGMAbwB1AHMAdABpAGMAXwBpAG0AcABlAGQAYQBuAGMAZQBfAGQAbwBjAGsAAAAA"
-    "AP////8AAACNAP////sAAAA+AG8AbgBfAGEAeABpAHMAXwBmAHIAZQBxAHUAZQBuAGMAeQBfAHIAZQBzAHAAbwBuAHMA"
-    "ZQBfAGQAbwBjAGsIAAAF/AAAAXIAAAC6AP///wAAAAAAAAN2AAAABAAAAAQAAAAIAAAACPwAAAAA"
+    "AAAA/wAAAAD9AAAAAQAAAAAAAAXAAAAAAPwCAAAAAfwAAAAA/////wAAADAA/////AEAAAAD+wAAAB4AYQB0AGgAXwBl"
+    "AGQAaQB0AG8AcgBfAGQAbwBjAGsBAAAAAAAAAaQAAAAyAP////sAAAAiAG0AZQBzAGgAXwBwAHIAZQB2AGkAZQB3AF8A"
+    "ZABvAGMAawEAAAAAAAACCAAAADIA/////AAAAAAAAAIIAAAAewD////6AAAABAEAAAAF+wAAACwAaABvAHIAaQB6AG8A"
+    "bgB0AGEAbABfAGkAcwBvAGIAYQByAF8AZABvAGMAawEAAAAA/////wAAADIA////+wAAACgAdgBlAHIAdABpAGMAYQBs"
+    "AF8AaQBzAG8AYgBhAHIAXwBkAG8AYwBrAQAAAAD/////AAAAMgD////7AAAALgBhAGMAbwB1AHMAdABpAGMAXwBpAG0A"
+    "cABlAGQAYQBuAGMAZQBfAGQAbwBjAGsBAAAAAP////8AAAAyAP////sAAAA+AG8AbgBfAGEAeABpAHMAXwBmAHIAZQBx"
+    "AHUAZQBuAGMAeQBfAHIAZQBzAHAAbwBuAHMAZQBfAGQAbwBjAGsBAAAAAP////8AAAAyAP////sAAAAcAHMAcABpAG4A"
+    "bwByAGEAbQBhAF8AZABvAGMAawEAAAAA/////wAAADIA////AAAAAAAAAAAAAAAEAAAABAAAAAgAAAAI/AAAAAA="
 )
+OBSOLETE_DOCK_OBJECT_NAMES = ("plots_dock",)
+
+
+def _dock_state_bytes(dock_state: QByteArray | bytes | bytearray) -> bytes:
+    if isinstance(dock_state, bytes):
+        return dock_state
+    if isinstance(dock_state, bytearray):
+        return bytes(dock_state)
+    return bytes(dock_state)
+
+
+def _dock_state_contains_object_name(dock_state: QByteArray | bytes | bytearray, object_name: str) -> bool:
+    raw = _dock_state_bytes(dock_state)
+    return (
+        object_name.encode("utf-8") in raw
+        or object_name.encode("utf-16-be") in raw
+        or object_name.encode("utf-16-le") in raw
+    )
+
+
+def _dock_state_has_obsolete_object_names(dock_state: QByteArray | bytes | bytearray) -> bool:
+    return any(_dock_state_contains_object_name(dock_state, name) for name in OBSOLETE_DOCK_OBJECT_NAMES)
 
 
 class MainWindow(QMainWindow):
@@ -193,6 +218,7 @@ class MainWindow(QMainWindow):
 
         startup("Loading saved settings...")
         self.settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
+        self.setAcceptDrops(True)
         self.setWindowTitle(f"Boundary Lab Beta {__version__}")
         self.resize(1500, 900)
         self.imported_meshes: tuple[MeshDialogEntry, ...] = ()
@@ -227,6 +253,7 @@ class MainWindow(QMainWindow):
         self._use_final_isobar_resolution = False
         self._final_isobar_plots_rendered = False
         self._last_imported_mesh_focus_check_at = 0.0
+        self._last_mesh_preview_error: str | None = None
         self._plot_dpi_screen = None
         self._plot_dpi_window_handle = None
         self._plot_dpi_refresh_pending = False
@@ -348,6 +375,30 @@ class MainWindow(QMainWindow):
     def showEvent(self, event) -> None:  # noqa: N802 - Qt override
         super().showEvent(event)
         self._connect_plot_dpi_signals()
+
+    def dragEnterEvent(self, event) -> None:  # noqa: N802 - Qt override
+        if self._msh_drop_paths(event):
+            event.acceptProposedAction()
+            return
+        super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event) -> None:  # noqa: N802 - Qt override
+        if self._msh_drop_paths(event):
+            event.acceptProposedAction()
+            return
+        super().dragMoveEvent(event)
+
+    def dropEvent(self, event) -> None:  # noqa: N802 - Qt override
+        paths = self._msh_drop_paths(event)
+        if not paths:
+            super().dropEvent(event)
+            return
+        event.acceptProposedAction()
+        self._import_mesh_paths(paths)
+
+    @staticmethod
+    def _msh_drop_paths(event) -> list[Path]:
+        return [path for path in local_drop_paths(event) if path.suffix.lower() == ".msh"]
 
     def _connect_plot_dpi_signals(self) -> None:
         window = self.windowHandle()
@@ -758,6 +809,10 @@ class MainWindow(QMainWindow):
             return
         if 0 <= index < len(self.ath_scripts):
             self.active_ath_script_id = self.ath_scripts[index].id
+            # Reflect the selected tab's solve settings in the controls, but do not
+            # persist them to the global preferences — navigating tabs must not
+            # overwrite the user's saved normalization angles / polar step / distance.
+            self._apply_ath_solve_settings_to_controls(self._active_ath_solve_settings(), persist=False)
 
     @Slot()
     def add_ath_script(self) -> None:
@@ -852,6 +907,63 @@ class MainWindow(QMainWindow):
         self.settings.setValue("solve/freq_max_hz", int(self.freq_max_spin.value()))
         self.settings.setValue("solve/freq_count", int(self.freq_count_spin.value()))
 
+    def _active_ath_solve_settings(self) -> AthSolveSettings:
+        script = self._active_script()
+        return parse_ath_solve_settings("" if script is None else script.config_text)
+
+    def _solver_ath_solve_settings(self) -> AthSolveSettings:
+        active_settings = self._active_ath_solve_settings()
+        if self._has_ath_solve_metadata(active_settings):
+            return active_settings
+
+        for script, _result in self._enabled_ath_results():
+            settings = parse_ath_solve_settings(script.config_text)
+            if self._has_ath_solve_metadata(settings):
+                return settings
+        return active_settings
+
+    @staticmethod
+    def _has_ath_solve_metadata(settings: AthSolveSettings) -> bool:
+        return any(
+            value is not None
+            for value in (
+                settings.freq_min_hz,
+                settings.freq_max_hz,
+                settings.freq_count,
+                settings.polar_min_angle_deg,
+                settings.polar_max_angle_deg,
+                settings.polar_step_deg,
+                settings.polar_distance_m,
+                settings.horizontal_norm_angle_deg,
+                settings.vertical_norm_angle_deg,
+            )
+        )
+
+    def _apply_ath_solve_settings_to_controls(self, solve_settings: AthSolveSettings, *, persist: bool = True) -> None:
+        if solve_settings.freq_min_hz is not None:
+            self.freq_min_spin.setValue(self._spin_clamped_int(self.freq_min_spin, solve_settings.freq_min_hz))
+        if solve_settings.freq_max_hz is not None:
+            self.freq_max_spin.setValue(self._spin_clamped_int(self.freq_max_spin, solve_settings.freq_max_hz))
+        if solve_settings.freq_count is not None:
+            self.freq_count_spin.setValue(self._spin_clamped_int(self.freq_count_spin, solve_settings.freq_count))
+
+        preference_updates = {}
+        if solve_settings.polar_step_deg is not None:
+            preference_updates["polar_angle_step_deg"] = float(solve_settings.polar_step_deg)
+        if solve_settings.polar_distance_m is not None:
+            preference_updates["polar_observation_distance_m"] = float(solve_settings.polar_distance_m)
+        if solve_settings.horizontal_norm_angle_deg is not None:
+            preference_updates["horizontal_normalization_angle"] = float(solve_settings.horizontal_norm_angle_deg)
+        if solve_settings.vertical_norm_angle_deg is not None:
+            preference_updates["vertical_normalization_angle"] = float(solve_settings.vertical_norm_angle_deg)
+        if preference_updates and persist:
+            self.preferences = replace(self.preferences, **preference_updates)
+            self._save_preferences()
+
+    @staticmethod
+    def _spin_clamped_int(spin: QSpinBox, value: float) -> int:
+        return min(max(int(round(value)), int(spin.minimum())), int(spin.maximum()))
+
     def _restore_window_state(self) -> None:
         geometry = self.settings.value("window/geometry")
         if geometry is not None:
@@ -861,7 +973,10 @@ class MainWindow(QMainWindow):
         if dock_state is None:
             dock_state = QByteArray.fromBase64(DEFAULT_DOCK_STATE_B64.encode("ascii"))
         if dock_state is not None:
-            self.workspace.restoreState(dock_state)
+            if _dock_state_has_obsolete_object_names(dock_state):
+                self.settings.remove("window/dock_state")
+            elif not self.workspace.restoreState(dock_state):
+                self.settings.remove("window/dock_state")
         for dock_id in ("editor", "preview"):
             self._sync_panel_view_action(dock_id)
         for entry in self.plot_entries:
@@ -922,7 +1037,7 @@ class MainWindow(QMainWindow):
                 MeshDialogEntry(
                     name=script.mesh_name,
                     source_file=str(result.solver_msh_path),
-                    scale_factor=float(script.mesh_scale_factor),
+                    scale_factor=normalize_ath_mesh_scale(script.mesh_scale_factor),
                     translation_mm=script.mesh_translation_mm,
                     enabled=script.mesh_enabled,
                     locked=True,
@@ -942,12 +1057,76 @@ class MainWindow(QMainWindow):
                     script.id,
                     mesh_enabled=bool(mesh.enabled),
                     mesh_translation_mm=mesh.translation_mm,
-                    mesh_scale_factor=float(mesh.scale_factor),
+                    mesh_scale_factor=normalize_ath_mesh_scale(mesh.scale_factor),
                 )
             else:
                 imported_meshes.append(replace(mesh, locked=False))
         self.ath_scripts = scripts
         self.imported_meshes = tuple(imported_meshes)
+
+    def _clear_generated_result_for_script(self, script_id: str, reason: str) -> None:
+        self.ath_results_by_script_id.pop(script_id, None)
+        self.ath_scripts = replace_script(
+            self.ath_scripts,
+            script_id,
+            output_dir=None,
+            msh_path=None,
+            cleaned_msh_path=None,
+            config_path=None,
+        )
+        self.mesh_state_changed.emit(reason)
+
+    def _unique_imported_mesh_name(self, base_name: str) -> str:
+        sanitized = "".join(char if char.isalnum() or char in ("_", "-") else "_" for char in base_name).strip("_")
+        name = sanitized or "mesh"
+        used = {script.mesh_name for script in self.ath_scripts}
+        used.update(mesh.name for mesh in self.imported_meshes)
+        used.add(STITCHED_MESH_NAME)
+        if name not in used:
+            return name
+
+        suffix = 2
+        while f"{name}_{suffix}" in used:
+            suffix += 1
+        return f"{name}_{suffix}"
+
+    def _import_mesh_paths(self, paths: list[Path]) -> None:
+        if not paths:
+            return
+        if not self._confirm_clear_solved_data():
+            return
+
+        previous_meshes = self.imported_meshes
+        new_meshes = []
+        reserved_names = set()
+        for path in paths:
+            mesh_name = self._unique_imported_mesh_name(path.stem)
+            while mesh_name in reserved_names:
+                mesh_name = self._unique_imported_mesh_name(f"{mesh_name}_2")
+            reserved_names.add(mesh_name)
+            new_meshes.append(
+                MeshDialogEntry(
+                    name=mesh_name,
+                    source_file=str(path),
+                    enabled=True,
+                )
+            )
+        new_meshes = tuple(new_meshes)
+        try:
+            self.status_label.setText("Cleaning imported meshes...")
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            self.imported_meshes = (*self.imported_meshes, *new_meshes)
+            self.imported_meshes = self._clean_imported_meshes(self.imported_meshes)
+            self._refresh_imported_source_config()
+            self.mesh_state_changed.emit("mesh_files_imported")
+            self.solve_results_invalidated.emit("mesh_files_imported")
+            self.status_label.setText(f"Imported {len(new_meshes)} mesh file{'s' if len(new_meshes) != 1 else ''}")
+        except Exception as exc:
+            self.imported_meshes = previous_meshes
+            self.status_label.setText("Mesh import failed")
+            QMessageBox.critical(self, "Mesh import failed", str(exc))
+        finally:
+            QApplication.restoreOverrideCursor()
 
     def _project_imported_meshes_payload(self) -> list[dict]:
         return [self._mesh_entry_to_payload(mesh, absolute_paths=True) for mesh in self.imported_meshes]
@@ -979,6 +1158,26 @@ class MainWindow(QMainWindow):
         except (TypeError, ValueError):
             return DEFAULT_MESH_SCALE_FACTOR
         return scale_factor if scale_factor > 0.0 else DEFAULT_MESH_SCALE_FACTOR
+
+    @staticmethod
+    def _primary_solver_mesh_scale(mesh_configs: tuple[MeshConfig, ...]) -> float:
+        """Scale factor to advertise on ``SimulationConfig`` for the solved mesh.
+
+        Boundary Lab's own solver scales each mesh by its per-mesh
+        ``MeshConfig.scale_factor``, but ``SimulationConfig.mesh_file`` only points
+        at the primary mesh, and backends that consume that single file (e.g. the
+        HornLab Metal backend) read the top-level ``scale_factor``. Keep the two in
+        sync so a metre-scale mesh (per-mesh scale 1.0) is not re-scaled as if it
+        were millimetres.
+        """
+        if not mesh_configs or mesh_configs[0].scale_factor is None:
+            return DEFAULT_MESH_SCALE_FACTOR
+        return float(mesh_configs[0].scale_factor)
+
+    def _native_check_open_edges_for_solver(self) -> bool:
+        if self.symmetry == "off":
+            return True
+        return all(native_check_open_edges_for_ath_config(script.config_text) for script, _result in self._enabled_ath_results())
 
     def _script_for_mesh_name(self, mesh_name: str) -> AthScriptState | None:
         return next((script for script in self.ath_scripts if script.mesh_name == mesh_name), None)
@@ -1179,6 +1378,7 @@ class MainWindow(QMainWindow):
             QApplication.setOverrideCursor(Qt.WaitCursor)
             self.status_label.setText(f"Reloading updated mesh file{'s' if len(updated_names) != 1 else ''}...")
             self.imported_meshes = self._clean_imported_meshes(self.imported_meshes)
+            self._refresh_imported_source_config()
             self.mesh_state_changed.emit("imported_mesh_files_reloaded")
             self.solve_results_invalidated.emit("imported_mesh_files_reloaded")
             names = ", ".join(updated_names)
@@ -1285,7 +1485,7 @@ class MainWindow(QMainWindow):
                 MeshConfig(
                     name=script.mesh_name,
                     file=str(solver_result.solver_msh_path_for_symmetry(symmetry)),
-                    scale_factor=float(script.mesh_scale_factor),
+                    scale_factor=normalize_ath_mesh_scale(script.mesh_scale_factor),
                     translation_m=tuple(value / 1000.0 for value in script.mesh_translation_mm),
                 )
             )
@@ -1437,11 +1637,13 @@ class MainWindow(QMainWindow):
     def _refresh_mesh_preview(self) -> None:
         if not self._has_solver_meshes():
             self.preview.clear()
+            self._last_mesh_preview_error = None
             return
         try:
             mesh_configs = self._solver_mesh_configs()
             if not mesh_configs:
                 self.preview.clear()
+                self._last_mesh_preview_error = None
                 return
             surface_tags_by_mesh = {
                 mesh_cfg.name: read_surface_physical_names(Path(mesh_cfg.file)) for mesh_cfg in mesh_configs
@@ -1455,17 +1657,20 @@ class MainWindow(QMainWindow):
                 surface_tags_by_mesh=surface_tags_by_mesh,
                 symmetry=self.symmetry,
             )
+            self._last_mesh_preview_error = None
         except Exception as exc:
             if str(exc) == STITCH_FAILURE_MESSAGE and self.stitch_imported_meshes:
                 self._refresh_unstitched_mesh_preview_after_stitch_failure()
                 return
             self.preview.clear()
+            self._set_mesh_preview_error(exc)
 
     def _refresh_unstitched_mesh_preview_after_stitch_failure(self) -> None:
         try:
             mesh_configs = self._stitch_candidate_mesh_configs()
             if not mesh_configs:
                 self.preview.clear()
+                self._last_mesh_preview_error = None
                 return
             surface_tags_by_mesh = {
                 mesh_cfg.name: read_surface_physical_names(Path(mesh_cfg.file)) for mesh_cfg in mesh_configs
@@ -1476,9 +1681,17 @@ class MainWindow(QMainWindow):
                 surface_tags_by_mesh=surface_tags_by_mesh,
                 symmetry=self.symmetry,
             )
+            self._last_mesh_preview_error = None
             self.status_label.setText("Mesh preview showing unstitched meshes; stitching failed")
-        except Exception:
+        except Exception as exc:
             self.preview.clear()
+            self._set_mesh_preview_error(exc)
+
+    def _set_mesh_preview_error(self, exc: Exception) -> None:
+        message = str(exc) or type(exc).__name__
+        self._last_mesh_preview_error = message
+        if hasattr(self, "status_label"):
+            self.status_label.setText(f"Mesh preview failed: {message}")
 
     def _load_source_config_by_name(self) -> dict[str, dict]:
         return load_source_config_by_name(self.settings)
@@ -1527,6 +1740,9 @@ class MainWindow(QMainWindow):
             config_by_name=self._load_source_config_by_name(),
         )
 
+    def _refresh_imported_source_config(self) -> None:
+        self._apply_saved_imported_source_config(self._surface_tags_for_meshes())
+
     def closeEvent(self, event) -> None:  # noqa: N802 - Qt override
         if not self._confirm_unsaved_project_changes("close"):
             event.ignore()
@@ -1570,8 +1786,6 @@ class MainWindow(QMainWindow):
     def _ensure_ath_runtime_config(self) -> None:
         ath_exe = self._find_ath_exe()
         ath_cfg = ath_exe.parent / "ath.cfg"
-        if not ath_cfg.exists():
-            return
         write_ath_output_root(ath_cfg, ATH_OUTPUT_ROOT)
         write_ath_gmsh_path(ath_cfg, GMSH_BUNDLE_EXE)
 
@@ -1597,15 +1811,72 @@ class MainWindow(QMainWindow):
                 else self._active_script()
             )
             if script is None:
-                script = new_script(unique_script_name(path.stem, self.ath_scripts), config_text)
+                script = replace(new_script(unique_script_name(path.stem, self.ath_scripts), config_text), config_path=str(path))
                 self.ath_scripts = (*self.ath_scripts, script)
-                self.active_ath_script_id = script.id
             else:
-                self.ath_scripts = replace_script(self.ath_scripts, script.id, config_text=config_text)
+                self.ath_scripts = replace_script(
+                    self.ath_scripts,
+                    script.id,
+                    config_text=config_text,
+                    output_dir=None,
+                    msh_path=None,
+                    cleaned_msh_path=None,
+                    config_path=str(path),
+                )
+            self.active_ath_script_id = script.id
+            if hasattr(self, "ath_results_by_script_id"):
+                self.ath_results_by_script_id.pop(script.id, None)
+                imported_result = self._discover_imported_ath_output(path)
+                if imported_result is not None:
+                    result = self._apply_saved_source_config_to_result(imported_result, script.mesh_name)
+                    self.ath_results_by_script_id[script.id] = result
+                    self.ath_scripts = replace_script(
+                        self.ath_scripts,
+                        script.id,
+                        output_dir=str(result.output_dir),
+                        msh_path=str(result.msh_path),
+                        cleaned_msh_path=None if result.cleaned_msh_path is None else str(result.cleaned_msh_path),
+                        config_path=str(result.config_path),
+                    )
+            self._apply_ath_solve_settings_to_controls(parse_ath_solve_settings(config_text))
             self._rebuild_ath_script_tabs()
             self.status_label.setText(f"Imported {path}")
+            if hasattr(self, "mesh_state_changed") and script.id in getattr(self, "ath_results_by_script_id", {}):
+                self.mesh_state_changed.emit("ath_config_imported_with_existing_mesh")
         except Exception as exc:
             QMessageBox.critical(self, "Import failed", str(exc))
+
+    def _discover_imported_ath_output(self, path: Path) -> AthRunResult | None:
+        for run_root, case_name in self._imported_ath_output_candidates(path):
+            try:
+                return discover_ath_output(
+                    run_root=run_root,
+                    case_name=case_name,
+                    config_path=path,
+                )
+            except Exception:
+                continue
+        return None
+
+    @staticmethod
+    def _imported_ath_output_candidates(path: Path) -> tuple[tuple[Path, str], ...]:
+        path = path.resolve()
+        candidates: list[tuple[Path, str]] = []
+
+        if path.name.lower() == "config.txt":
+            candidates.append((path.parent.parent, path.parent.name))
+        if path.parent.name == path.stem:
+            candidates.append((path.parent.parent, path.parent.name))
+        candidates.append((path.parent, path.stem))
+
+        unique: list[tuple[Path, str]] = []
+        seen: set[tuple[Path, str]] = set()
+        for run_root, case_name in candidates:
+            key = (run_root, case_name)
+            if key not in seen:
+                unique.append(key)
+                seen.add(key)
+        return tuple(unique)
 
     @Slot()
     def new_project(self) -> None:
@@ -1781,6 +2052,7 @@ class MainWindow(QMainWindow):
                     result, script.mesh_name
                 )
         self._rebuild_ath_script_tabs()
+        self._apply_ath_solve_settings_to_controls(self._active_ath_solve_settings())
         self.imported_meshes = self._mesh_entries_from_payload(payload.get("imported_meshes", []))
         self.stitch_imported_meshes = bool(payload.get("stitch_imported_meshes", False))
         self.symmetry = str(payload.get("symmetry", "off")).strip().lower()
@@ -2023,6 +2295,7 @@ class MainWindow(QMainWindow):
             if symmetry_enabled:
                 self.symmetry = symmetry
             self.imported_meshes = self._clean_imported_meshes(self.imported_meshes)
+            self._refresh_imported_source_config()
             self.mesh_state_changed.emit("mesh_config_changed")
             self.solve_results_invalidated.emit("mesh_config_changed")
             self.status_label.setText(
@@ -2172,6 +2445,7 @@ class MainWindow(QMainWindow):
             return
 
         self.solve_results_invalidated.emit("geometry_generation_started")
+        self._clear_generated_result_for_script(script.id, "geometry_generation_started")
         self.status_label.setText(f"Generating {script.name}...")
         self.solve_button.setEnabled(False)
         self.generate_button.setEnabled(False)
@@ -2229,7 +2503,12 @@ class MainWindow(QMainWindow):
             config_path=str(result.config_path),
         )
         self.mesh_state_changed.emit("ath_mesh_generated")
-        self.status_label.setText(f"Generated and cleaned {result.output_dir}")
+        if self._last_mesh_preview_error:
+            self.status_label.setText(
+                f"Generated and cleaned {result.output_dir}; mesh preview failed: {self._last_mesh_preview_error}"
+            )
+        else:
+            self.status_label.setText(f"Generated and cleaned {result.output_dir}")
         self._show_mesh_quality_warning(result)
 
     @Slot(str)
@@ -2263,18 +2542,19 @@ class MainWindow(QMainWindow):
         if not self._has_solver_meshes():
             QMessageBox.warning(self, "No mesh", "Enable at least one generated or imported mesh before solving.")
             return
-        radiators = self._all_radiators()
-        if not radiators:
-            QMessageBox.warning(
-                self, "No driven surfaces", "Open Source Config and mark at least one surface as Driven."
-            )
-            return
         if self._disable_symmetry_if_backend_unsupported():
             self.mesh_state_changed.emit("symmetry_disabled_for_backend")
 
         try:
             self.imported_meshes = self._clean_imported_meshes(self.imported_meshes)
+            self._refresh_imported_source_config()
             mesh_configs = self._solver_mesh_configs()
+            radiators = self._all_radiators()
+            if not radiators:
+                QMessageBox.warning(
+                    self, "No driven surfaces", "Open Source Config and mark at least one surface as Driven."
+                )
+                return
             radiators = self._radiators_for_solver_meshes(mesh_configs, radiators)
         except Exception as exc:
             self._show_stitch_or_generic_error("Imported mesh preparation failed", exc)
@@ -2285,11 +2565,20 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "Symmetry validation failed", str(exc))
             return
 
+        ath_solve_settings = self._solver_ath_solve_settings()
+        self._apply_ath_solve_settings_to_controls(ath_solve_settings)
         freq_min = float(min(self.freq_min_spin.value(), self.freq_max_spin.value()))
         freq_max = float(max(self.freq_min_spin.value(), self.freq_max_spin.value()))
         freq_count = int(self.freq_count_spin.value())
         freqs = build_log_frequencies(freq_min, freq_max, freq_count)
         ordered_freqs = order_frequencies_for_live_plotting(freqs)
+        min_angle = -180.0 if ath_solve_settings.polar_min_angle_deg is None else ath_solve_settings.polar_min_angle_deg
+        max_angle = 180.0 if ath_solve_settings.polar_max_angle_deg is None else ath_solve_settings.polar_max_angle_deg
+        step_size = (
+            self.preferences.polar_angle_step_deg
+            if ath_solve_settings.polar_step_deg is None
+            else ath_solve_settings.polar_step_deg
+        )
 
         channels = self._channels_for_solver_radiators(radiators)
         config = SimulationConfig(
@@ -2301,8 +2590,11 @@ class MainWindow(QMainWindow):
             meshes=mesh_configs,
             radiators=radiators,
             channels=channels,
+            scale_factor=self._primary_solver_mesh_scale(mesh_configs),
             distance=self.preferences.polar_observation_distance_m,
-            step_size=self.preferences.polar_angle_step_deg,
+            step_size=step_size,
+            min_angle=min_angle,
+            max_angle=max_angle,
             use_burton_miller=self.preferences.use_burton_miller,
             gmres_tolerance=self.preferences.gmres_tolerance,
             workers=1,
@@ -2311,6 +2603,7 @@ class MainWindow(QMainWindow):
             spherical_sampling_enabled=self.preferences.spherical_sampling_enabled,
             spherical_sampling_points=balloon_sampling_points(self.preferences.balloon_angle_precision_deg),
             symmetry=self.symmetry,
+            native_check_open_edges=self._native_check_open_edges_for_solver(),
         )
 
         self.live_dataset = None

--- a/src/blab/ui/mesh_preview.py
+++ b/src/blab/ui/mesh_preview.py
@@ -9,7 +9,6 @@ import numpy as np
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
-from blab.ath import AthRunResult, read_surface_physical_names
 from blab.config import MeshConfig
 
 try:  # pragma: no cover - optional visual dependency
@@ -77,13 +76,7 @@ class MeshPreview(QWidget):
         self._actor_surface_labels = {}
         self.hover_label.setText("")
         self._set_total_element_count(0)
-
-    def load_ath_result(self, result: AthRunResult) -> None:
-        self.load_mesh_configs(
-            (MeshConfig(name="ath", file=str(result.solver_msh_path), scale_factor=0.001),),
-            driven_surfaces={("ath", radiator.tag) for radiator in result.radiators},
-            surface_tags_by_mesh={"ath": read_surface_physical_names(result.solver_msh_path)},
-        )
+        self._request_render()
 
     def load_msh(
         self,
@@ -122,6 +115,7 @@ class MeshPreview(QWidget):
             )
             self._add_orientation_guides(display_points)
             self._restore_camera_or_reset(camera_position)
+            self._request_render()
             return
 
         names_by_tag = {tag: name for name, tag in (surface_tags or {}).items()}
@@ -149,6 +143,7 @@ class MeshPreview(QWidget):
 
         self._add_orientation_guides(display_points)
         self._restore_camera_or_reset(camera_position)
+        self._request_render()
 
     def load_mesh_configs(
         self,
@@ -187,6 +182,7 @@ class MeshPreview(QWidget):
         if preview_points:
             self._add_orientation_guides(display_points)
         self._restore_camera_or_reset(camera_position)
+        self._request_render()
 
     def _add_msh_mesh(
         self,
@@ -327,6 +323,19 @@ class MeshPreview(QWidget):
             self.viewer.reset_camera_clipping_range()
         except Exception:
             self.viewer.reset_camera()
+
+    def _request_render(self) -> None:
+        if self.viewer is None:
+            return
+        render = getattr(self.viewer, "render", None)
+        if callable(render):
+            try:
+                render()
+            except Exception:
+                pass
+        update = getattr(self.viewer, "update", None)
+        if callable(update):
+            update()
 
     def _add_orientation_guides(self, points: np.ndarray) -> None:
         if self.viewer is None or pv is None:

--- a/src/blab/ui/plots.py
+++ b/src/blab/ui/plots.py
@@ -311,10 +311,17 @@ class IsobarCanvas(FigureCanvas):
             )
         )
 
-    def _color_mapping(self, clip_min_db: float, clip_max_db: float, contour_step_db: float):
+    def _color_mapping(
+        self,
+        clip_min_db: float,
+        clip_max_db: float,
+        contour_step_db: float,
+        *,
+        discrete: bool = True,
+    ):
         cmap = self._isobar_colormap()
         boundaries = self._color_boundaries(clip_min_db, clip_max_db, contour_step_db)
-        if boundaries.size >= 2:
+        if discrete and boundaries.size >= 2:
             return cmap, BoundaryNorm(boundaries, cmap.N)
         return cmap, Normalize(vmin=clip_min_db, vmax=clip_max_db)
 
@@ -348,16 +355,6 @@ class IsobarCanvas(FigureCanvas):
         self._colorbar.set_ticks(self._colorbar_ticks(clip_min_db, clip_max_db, contour_step_db))
         self._colorbar.ax.tick_params(labelsize=PLOT_TICK_SIZE)
 
-    def _image_from_values(
-        self,
-        clipped: np.ndarray,
-        clip_min_db: float,
-        clip_max_db: float,
-        contour_step_db: float,
-    ) -> np.ndarray:
-        cmap, norm = self._color_mapping(clip_min_db, clip_max_db, contour_step_db)
-        return np.asarray(cmap(norm(clipped)), dtype=np.float32)
-
     def update_plot(
         self,
         freqs_hz: np.ndarray,
@@ -372,14 +369,22 @@ class IsobarCanvas(FigureCanvas):
         freqs_hz = np.asarray(freqs_hz, dtype=np.float32)
         angles_deg = np.asarray(angles_deg, dtype=np.float32)
         clipped = np.clip(np.asarray(values_db, dtype=np.float32), clip_min_db, clip_max_db)
+        finite = clipped[np.isfinite(clipped)]
+        data_span_db = 0.0 if finite.size == 0 else float(np.max(finite) - np.min(finite))
         clip = (float(clip_min_db), float(clip_max_db))
         shading = str(shading or LIVE_ISOBAR_SHADING)
         contour_step_db = max(0.0, float(contour_step_db))
+        discrete_colors = contour_step_db <= 0.0 or data_span_db >= 2.0 * contour_step_db
         render_mode = "image" if shading == FINAL_ISOBAR_SHADING else "mesh"
 
         if freqs_hz.size >= 2 and angles_deg.size >= 2:
             self._remove_artist("_line_artist")
-            cmap, norm = self._color_mapping(clip_min_db, clip_max_db, contour_step_db)
+            cmap, norm = self._color_mapping(
+                clip_min_db,
+                clip_max_db,
+                contour_step_db,
+                discrete=discrete_colors,
+            )
             self._update_colorbar(clip_min_db, clip_max_db, contour_step_db, cmap, norm)
             if render_mode == "image":
                 self._x_axis_mode = "log_image"

--- a/src/blab/ui/project_io.py
+++ b/src/blab/ui/project_io.py
@@ -8,7 +8,7 @@ wire/API serialization stays in ``blab.protocol``.
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 PROJECT_SCHEMA_VERSION = 1
@@ -154,7 +154,7 @@ def _resolve_path_fields(payload: dict[str, Any], base_dir: Path, fields: tuple[
         if not text:
             continue
         path = Path(text)
-        if path.is_absolute():
+        if path.is_absolute() or PureWindowsPath(text).drive:
             continue
         payload[field] = str((base_dir / path).resolve())
 

--- a/src/blab/ui/project_state.py
+++ b/src/blab/ui/project_state.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_SCRIPT_NAME = "ath"
-DEFAULT_MESH_SCALE_FACTOR = 0.001
+# Ath-family meshes (real Ath/ABEC output and the HornLab mesher in millimetre
+# mode) are millimetres; the solver converts to metres by this factor.
+DEFAULT_ATH_MESH_SCALE_FACTOR = 0.001
 
 
 @dataclass(frozen=True)
@@ -17,7 +19,7 @@ class AthScriptState:
     name: str
     config_text: str
     mesh_enabled: bool = True
-    mesh_scale_factor: float = DEFAULT_MESH_SCALE_FACTOR
+    mesh_scale_factor: float = DEFAULT_ATH_MESH_SCALE_FACTOR
     mesh_translation_mm: tuple[float, float, float] = (0.0, 0.0, 0.0)
     output_dir: str | None = None
     msh_path: str | None = None
@@ -59,7 +61,7 @@ def script_to_payload(script: AthScriptState, *, absolute_paths: bool = False) -
         "name": script.name,
         "config_text": script.config_text,
         "mesh_enabled": bool(script.mesh_enabled),
-        "mesh_scale_factor": float(script.mesh_scale_factor),
+        "mesh_scale_factor": normalize_ath_mesh_scale(script.mesh_scale_factor),
         "mesh_translation_mm": [int(round(value)) for value in script.mesh_translation_mm],
         "output_dir": _path_payload(script.output_dir, absolute_paths),
         "msh_path": _path_payload(script.msh_path, absolute_paths),
@@ -81,7 +83,7 @@ def script_from_payload(payload: object) -> AthScriptState | None:
         name=name,
         config_text=str(payload.get("config_text", "")),
         mesh_enabled=bool(payload.get("mesh_enabled", True)),
-        mesh_scale_factor=_positive_float(payload.get("mesh_scale_factor"), DEFAULT_MESH_SCALE_FACTOR),
+        mesh_scale_factor=normalize_ath_mesh_scale(payload.get("mesh_scale_factor")),
         mesh_translation_mm=tuple(float(int(round(float(value)))) for value in translation),
         output_dir=_optional_path_text(payload.get("output_dir")),
         msh_path=_optional_path_text(payload.get("msh_path")),
@@ -119,9 +121,6 @@ def _optional_path_text(value: object) -> str | None:
     return text or None
 
 
-def _positive_float(value: object, default: float) -> float:
-    try:
-        parsed = float(value)
-    except (TypeError, ValueError):
-        return default
-    return parsed if parsed > 0.0 else default
+def normalize_ath_mesh_scale(_value: object) -> float:
+    """Ath-generated meshes are always in millimetres; legacy/custom factors are ignored."""
+    return DEFAULT_ATH_MESH_SCALE_FACTOR

--- a/src/blab/ui/source_channel_config.py
+++ b/src/blab/ui/source_channel_config.py
@@ -8,7 +8,12 @@ from pathlib import Path
 
 from PySide6.QtCore import QSettings
 
-from blab.ath import AthRunResult, read_surface_physical_names
+from blab.ath import (
+    COMPLEX_RADIATOR_DRIVES_DB,
+    DRIVEN_DIAPHRAGM_PHYSICAL_NAME,
+    AthRunResult,
+    read_surface_physical_names,
+)
 from blab.config import ChannelConfig, CrossoverConfig, RadiatorConfig
 
 SOURCE_CONFIG_SETTINGS_KEY = "source/config_by_name"
@@ -183,6 +188,10 @@ def apply_saved_imported_source_config(
     config_by_name: dict[str, dict],
 ) -> tuple[RadiatorConfig, ...]:
     existing_by_key = {(radiator.mesh, radiator.tag): radiator for radiator in existing_radiators}
+    default_radiators_by_name = _default_imported_radiators_by_surface_name(
+        surface_tags=surface_tags,
+        generated_mesh_names=generated_mesh_names,
+    )
     radiators = []
     for surface_name, (mesh_name, tag) in sorted(
         surface_tags.items(), key=lambda item: (item[1][0], item[1][1], item[0])
@@ -205,7 +214,48 @@ def apply_saved_imported_source_config(
             )
         elif existing is not None:
             radiators.append(existing)
+        elif surface_name in default_radiators_by_name:
+            radiators.append(default_radiators_by_name[surface_name])
     return tuple(radiators)
+
+
+def _default_imported_radiators_by_surface_name(
+    *,
+    surface_tags: dict[str, tuple[str, int]],
+    generated_mesh_names: set[str],
+) -> dict[str, RadiatorConfig]:
+    by_mesh: dict[str, dict[str, tuple[str, int]]] = {}
+    for surface_name, (mesh_name, tag) in surface_tags.items():
+        if mesh_name in generated_mesh_names:
+            continue
+        label = surface_name.rsplit(":", maxsplit=1)[-1]
+        by_mesh.setdefault(mesh_name, {})[label] = (surface_name, tag)
+
+    defaults = {}
+    for mesh_name, labels in by_mesh.items():
+        if set(COMPLEX_RADIATOR_DRIVES_DB).issubset(labels):
+            for physical_name, level_db in COMPLEX_RADIATOR_DRIVES_DB.items():
+                surface_name, tag = labels[physical_name]
+                defaults[surface_name] = RadiatorConfig(
+                    name=surface_name,
+                    mesh=mesh_name,
+                    tag=tag,
+                    level_db=level_db,
+                )
+            continue
+
+        surface = labels.get(DRIVEN_DIAPHRAGM_PHYSICAL_NAME)
+        if surface is None:
+            continue
+        surface_name, tag = surface
+        defaults[surface_name] = RadiatorConfig(
+            name=surface_name,
+            mesh=mesh_name,
+            tag=tag,
+            channel="main",
+        )
+
+    return defaults
 
 
 def _load_config_by_name(settings: QSettings, key: str) -> dict[str, dict]:

--- a/tests/test_ath_config.py
+++ b/tests/test_ath_config.py
@@ -1,0 +1,74 @@
+import pytest
+
+from blab.ath_config import native_check_open_edges_for_ath_config, parse_ath_solve_settings
+
+
+def test_parse_ath_solve_settings_reads_abec_frequency_and_polar_metadata() -> None:
+    settings = parse_ath_solve_settings(
+        """
+        ; Ath version V2025-06
+        ABEC.Abscissa = 1
+        ABEC.MeshFrequency = 1000
+        ABEC.NumFrequencies = 40
+        ABEC.Polars:SPL_H = {
+        Distance = 2
+        MapAngleRange = 0,180,37
+        NormAngle = 0
+        }
+        ABEC.Polars:SPL_V = {
+        Distance = 2
+        Inclination = 90
+        MapAngleRange = 0,180,37
+        NormAngle = 5
+        }
+        ABEC.SimType = 2
+        ABEC.f1 = 100 ; [Hz]
+        ABEC.f2 = 20000
+        """
+    )
+
+    assert settings.freq_min_hz == 100.0
+    assert settings.freq_max_hz == 20000.0
+    assert settings.freq_count == 40
+    assert settings.polar_min_angle_deg == 0.0
+    assert settings.polar_max_angle_deg == 180.0
+    assert settings.polar_step_deg == pytest.approx(5.0)
+    assert settings.polar_distance_m == 2.0
+    assert settings.horizontal_norm_angle_deg == 0.0
+    assert settings.vertical_norm_angle_deg == 5.0
+
+
+def test_parse_ath_solve_settings_accepts_named_horizontal_polar_aliases() -> None:
+    settings = parse_ath_solve_settings(
+        """
+        ABEC.NumFrequencies = 96
+        ABEC.Polars:hor = {
+        MapAngleRange = -180,180,96
+        NormAngle = 20
+        }
+        ABEC.f1 = 500
+        ABEC.f2 = 16000
+        """
+    )
+
+    assert settings.freq_count == 96
+    assert settings.polar_min_angle_deg == -180.0
+    assert settings.polar_max_angle_deg == 180.0
+    assert settings.polar_step_deg == pytest.approx(360.0 / 95.0)
+    assert settings.horizontal_norm_angle_deg == 20.0
+    assert settings.vertical_norm_angle_deg == 20.0
+
+
+@pytest.mark.parametrize(
+    ("config_text", "expected"),
+    (
+        ("Mesh.Mode = bare\n", False),
+        ("mode = open\n", False),
+        ("mode = freestanding\n", True),
+        ("ABEC.SimType = 1\n", True),
+        ("Enclosure.Depth = 120\n", True),
+        ("", True),
+    ),
+)
+def test_native_open_edge_check_only_opts_out_for_bare_modes(config_text: str, expected: bool) -> None:
+    assert native_check_open_edges_for_ath_config(config_text) is expected

--- a/tests/test_ath_live.py
+++ b/tests/test_ath_live.py
@@ -1,4 +1,7 @@
 import json
+import os
+import threading
+import time
 from pathlib import Path
 
 import meshio
@@ -6,7 +9,10 @@ import numpy as np
 import pytest
 
 from blab.ath import (
+    AthCancelledError,
     AthProcessRunner,
+    HornlabMesherRunner,
+    HornlabWaveguideGenerationError,
     ath_mirror_axes_for_result,
     ath_mirror_axes_from_solving_file,
     clean_ath_mesh_output,
@@ -14,8 +20,10 @@ from blab.ath import (
     detect_ath_radiators,
     discover_ath_output,
     find_physical_tag_by_name,
+    generate_waveguide_mesh,
     read_ath_output_root,
     read_surface_physical_names,
+    run_hornlab_waveguide,
     write_ath_gmsh_path,
     write_ath_output_root,
 )
@@ -32,10 +40,7 @@ from blab.live import (
 from blab.mesh_clean import triangle_quality_warning
 from blab.postprocess import PrepConfig
 
-
-def _write_minimal_msh(path: Path) -> None:
-    path.write_text(
-        """
+MINIMAL_MSH_TEXT = """
 $MeshFormat
 2.2 0 8
 $EndMeshFormat
@@ -44,9 +49,53 @@ $PhysicalNames
 2 1 "Rigid"
 2 2 "SD1D1001"
 $EndPhysicalNames
-""".strip(),
+""".strip()
+
+
+def _write_minimal_msh(path: Path) -> None:
+    path.write_text(MINIMAL_MSH_TEXT, encoding="utf-8")
+
+
+def _install_fake_hornlab_mesher(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    build_body: str | None = None,
+    expected_config: str = "Length = 10",
+) -> None:
+    package_root = tmp_path / "fake_hornlab_mesher"
+    package_dir = package_root / "hornlab_mesher"
+    package_dir.mkdir(parents=True)
+    if build_body is None:
+        build_body = f"    output_path.write_text({MINIMAL_MSH_TEXT!r}, encoding='utf-8')\n"
+
+    (package_dir / "__init__.py").write_text(
+        f"""
+from pathlib import Path
+
+
+def load_config(config_path):
+    if Path(config_path).read_text(encoding="utf-8") != {expected_config!r}:
+        raise AssertionError("unexpected config text")
+    return {{"formula": "OSSE"}}
+
+
+def build_from_config(config, output_path):
+    if config.get("formula") != "OSSE":
+        raise AssertionError("unexpected config")
+    if config.get("mesh", {{}}).get("scale_to_metres") is not False:
+        raise AssertionError("Boundary Lab must request millimetre output")
+    output_path = Path(output_path)
+{build_body}
+""".lstrip(),
         encoding="utf-8",
     )
+
+    current_pythonpath = os.environ.get("PYTHONPATH")
+    pythonpath = str(package_root)
+    if current_pythonpath:
+        pythonpath = f"{package_root}{os.pathsep}{current_pythonpath}"
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
 
 
 class _FakeAthProcess:
@@ -93,6 +142,7 @@ def test_ath_process_runner_discovers_output_after_process_exit(tmp_path: Path, 
         popen_calls.append((args, kwargs))
         return _FakeAthProcess()
 
+    monkeypatch.setattr("blab.ath.sys.platform", "win32")
     monkeypatch.setattr("blab.ath.subprocess.Popen", fake_popen)
 
     result = AthProcessRunner().run(
@@ -105,6 +155,148 @@ def test_ath_process_runner_discovers_output_after_process_exit(tmp_path: Path, 
     assert result.msh_path == mesh_dir / "case.msh"
     assert (tmp_path / "runs" / "case.cfg").read_text(encoding="utf-8") == "Length = 10"
     assert popen_calls[0][0][0] == [str(ath_exe.resolve()), str(tmp_path / "runs" / "case.cfg")]
+
+
+def test_hornlab_waveguide_runner_writes_ath_compatible_result(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(tmp_path, monkeypatch)
+
+    result = run_hornlab_waveguide(
+        config_text="Length = 10",
+        run_root=tmp_path / "runs",
+        case_name="case",
+    )
+
+    assert result.output_dir == tmp_path / "runs" / "case"
+    assert result.msh_path == tmp_path / "runs" / "case" / "ABEC_FreeStanding" / "case.msh"
+    assert result.config_path == tmp_path / "runs" / "case.cfg"
+    assert result.driven_tag == 2
+    assert [(r.name, r.tag, r.level_db) for r in result.radiators] == [("throat", 2, 0.0)]
+
+
+@pytest.mark.parametrize(
+    ("quadrants", "expected_sym"),
+    (("1", "xy"), ("14", "x"), ("12", "y"), ("1234", ""), (None, "")),
+)
+def test_hornlab_symmetry_axes_from_config(quadrants: str | None, expected_sym: str) -> None:
+    from blab.ath import hornlab_symmetry_axes_from_config
+
+    config_text = "Length = 40\n" if quadrants is None else f"Mesh.Quadrants = {quadrants}\nLength = 40\n"
+    assert hornlab_symmetry_axes_from_config(config_text) == expected_sym
+
+
+def test_hornlab_waveguide_runner_writes_solving_file_for_reduced_quadrants(tmp_path: Path, monkeypatch) -> None:
+    config_text = "Mesh.Quadrants = 1"
+    _install_fake_hornlab_mesher(tmp_path, monkeypatch, expected_config=config_text)
+
+    result = run_hornlab_waveguide(config_text=config_text, run_root=tmp_path / "runs", case_name="case")
+
+    solving_path = result.msh_path.parent / "solving.txt"
+    assert solving_path.exists()
+    assert ath_mirror_axes_from_solving_file(solving_path) == ("x", "y")
+    # The written file must be the one mesh cleaning discovers for mirroring.
+    assert ath_mirror_axes_for_result(result) == ("x", "y")
+
+
+def test_hornlab_waveguide_runner_omits_solving_file_for_full_model(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(tmp_path, monkeypatch)
+
+    result = run_hornlab_waveguide(config_text="Length = 10", run_root=tmp_path / "runs", case_name="case")
+
+    assert not (result.msh_path.parent / "solving.txt").exists()
+    assert ath_mirror_axes_for_result(result) == ()
+
+
+def test_hornlab_waveguide_runner_is_safe_from_worker_threads(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(
+        tmp_path,
+        monkeypatch,
+        build_body=(
+            "    import signal\n"
+            "    signal.signal(signal.SIGTERM, signal.SIG_DFL)\n"
+            f"    output_path.write_text({MINIMAL_MSH_TEXT!r}, encoding='utf-8')\n"
+        ),
+    )
+
+    result_holder = {}
+
+    def run_in_thread() -> None:
+        try:
+            result_holder["result"] = run_hornlab_waveguide(
+                config_text="Length = 10",
+                run_root=tmp_path / "runs",
+                case_name="case",
+            )
+        except Exception as exc:
+            result_holder["error"] = exc
+
+    thread = threading.Thread(target=run_in_thread)
+    thread.start()
+    thread.join(timeout=10.0)
+
+    assert not thread.is_alive()
+    if "error" in result_holder:
+        raise result_holder["error"]
+
+    result = result_holder["result"]
+    assert result.msh_path == tmp_path / "runs" / "case" / "ABEC_FreeStanding" / "case.msh"
+    assert result.driven_tag == 2
+
+
+def test_hornlab_waveguide_runner_can_be_cancelled(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(
+        tmp_path,
+        monkeypatch,
+        build_body=(
+            "    import time\n"
+            "    time.sleep(30)\n"
+        ),
+    )
+    runner = HornlabMesherRunner()
+    result_holder = {}
+
+    def run_in_thread() -> None:
+        try:
+            result_holder["result"] = run_hornlab_waveguide(
+                config_text="Length = 10",
+                run_root=tmp_path / "runs",
+                case_name="case",
+                runner=runner,
+            )
+        except Exception as exc:
+            result_holder["error"] = exc
+
+    thread = threading.Thread(target=run_in_thread)
+    thread.start()
+    deadline = time.monotonic() + 5.0
+    while runner._process is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert runner._process is not None
+
+    runner.stop()
+    thread.join(timeout=10.0)
+
+    assert not thread.is_alive()
+    assert isinstance(result_holder.get("error"), AthCancelledError)
+
+
+def test_hornlab_waveguide_runner_reports_missing_optional_package(tmp_path: Path, monkeypatch) -> None:
+    class FakeProcess:
+        returncode = 1
+
+        def communicate(self, timeout=None):
+            return "", "ModuleNotFoundError: No module named 'hornlab_mesher'\n"
+
+        def poll(self):
+            return self.returncode
+
+    monkeypatch.setattr("blab.ath.subprocess.Popen", lambda *args, **kwargs: FakeProcess())
+
+    with pytest.raises(HornlabWaveguideGenerationError, match="not installed"):
+        run_hornlab_waveguide(
+            config_text="Length = 10",
+            run_root=tmp_path / "runs",
+            case_name="case",
+        )
 
 
 @pytest.mark.parametrize("platform_name", ("linux", "darwin"))
@@ -163,6 +355,7 @@ def test_ath_process_runner_reports_missing_wine_on_linux(tmp_path: Path, monkey
             case_name="case",
         )
 
+
 def test_ath_process_runner_stop_terminates_active_process(monkeypatch) -> None:
     runner = AthProcessRunner()
     process = _FakeAthProcess()
@@ -200,6 +393,30 @@ $EndPhysicalNames
     )
 
     assert read_surface_physical_names(msh_path) == {"SD1D1001": 2}
+
+
+def test_read_surface_physical_names_falls_back_to_triangle_tags(tmp_path: Path) -> None:
+    msh_path = tmp_path / "unnamed_tags.msh"
+    msh_path.write_text(
+        """
+$MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+3
+1 0 0 0
+2 1 0 0
+3 0 1 0
+$EndNodes
+$Elements
+1
+1 2 2 7 0 1 2 3
+$EndElements
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert read_surface_physical_names(msh_path) == {"Tag 7": 7}
 
 
 def test_discover_ath_output_finds_msh_and_driven_tag(tmp_path: Path) -> None:
@@ -826,3 +1043,128 @@ def test_export_polar_text_files_writes_relative_phase_for_channel_basis(tmp_pat
     assert (tmp_path / "V 90.txt").read_text(encoding="utf-8").splitlines() == [
         "1000.000000\t0.000\t-90.000",
     ]
+
+
+class _RecordingRunner:
+    """Stand-in for AthProcessRunner that records whether the Ath fallback ran."""
+
+    def __init__(self, *, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+        self.calls: list[dict] = []
+
+    def run(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def test_generate_waveguide_prefers_hornlab_mesher(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(tmp_path, monkeypatch)
+    runner = _RecordingRunner(exc=AssertionError("Ath must not run when the mesher succeeds"))
+    statuses: list[str] = []
+
+    result = generate_waveguide_mesh(
+        ath_exe=tmp_path / "ath" / "ath.exe",
+        config_text="Length = 10",
+        run_root=tmp_path / "runs",
+        case_name="case",
+        runner=runner,
+        on_status=statuses.append,
+    )
+
+    assert runner.calls == []  # the mesher handled it; Ath was never invoked
+    assert result.msh_path == tmp_path / "runs" / "case" / "ABEC_FreeStanding" / "case.msh"
+    assert any("HornLab" in status for status in statuses)
+
+
+def test_generate_waveguide_falls_back_to_ath_when_mesher_unsupported(tmp_path: Path, monkeypatch) -> None:
+    _install_fake_hornlab_mesher(
+        tmp_path,
+        monkeypatch,
+        build_body="    raise RuntimeError('unsupported geometry')\n",
+    )
+    sentinel = object()
+    runner = _RecordingRunner(result=sentinel)
+
+    result = generate_waveguide_mesh(
+        ath_exe=tmp_path / "ath" / "ath.exe",
+        config_text="Length = 10",
+        run_root=tmp_path / "runs",
+        case_name="case",
+        runner=runner,
+    )
+
+    assert len(runner.calls) == 1  # fell back to Ath exactly once
+    assert runner.calls[0]["ath_exe"] == tmp_path / "ath" / "ath.exe"
+    assert result is sentinel
+
+
+def test_write_ath_gmsh_path_stages_spaced_gmsh(tmp_path: Path, monkeypatch) -> None:
+    gmsh_dir = tmp_path / "boundary lab" / "gmsh-win"
+    gmsh_dir.mkdir(parents=True)
+    gmsh_exe = gmsh_dir / "gmsh.exe"
+    gmsh_exe.write_text("", encoding="utf-8")
+
+    stage = tmp_path / "cache"
+    monkeypatch.setattr("blab.ath._space_free_stage_bases", lambda: [stage])
+
+    ath_cfg = tmp_path / "ath.cfg"
+    ath_cfg.write_text("", encoding="utf-8")
+
+    staged = write_ath_gmsh_path(ath_cfg, gmsh_exe)
+
+    assert " " not in str(staged)
+    assert staged.resolve() == gmsh_exe.resolve()  # symlink resolves to the real exe
+    assert f'MeshCmd = "{staged} %f -"' in ath_cfg.read_text(encoding="utf-8")
+
+
+def test_write_ath_gmsh_path_keeps_space_free_gmsh(tmp_path: Path) -> None:
+    gmsh_exe = tmp_path / "gmsh-win" / "gmsh.exe"
+    gmsh_exe.parent.mkdir(parents=True)
+    gmsh_exe.write_text("", encoding="utf-8")
+
+    ath_cfg = tmp_path / "ath.cfg"
+    ath_cfg.write_text("", encoding="utf-8")
+
+    result = write_ath_gmsh_path(ath_cfg, gmsh_exe)
+
+    assert result == gmsh_exe.resolve()
+    assert f'MeshCmd = "{gmsh_exe.resolve()} %f -"' in ath_cfg.read_text(encoding="utf-8")
+
+
+def test_mesher_unsupported_reason_flags_throat_extension() -> None:
+    from blab.ath import _mesher_unsupported_reason
+
+    assert _mesher_unsupported_reason("Throat.Ext.Length = 15\nLength = 100") is not None
+    assert _mesher_unsupported_reason("Throat.Ext.Length = 15 ; mm\n") is not None
+    assert _mesher_unsupported_reason("Throat.Ext.Length = 0\n") is None
+    assert _mesher_unsupported_reason("Throat.Ext.Length =\n") is None
+    assert _mesher_unsupported_reason("Throat.Ext.Angle = 10\nLength = 100") is None
+    assert _mesher_unsupported_reason("Length = 100\n") is None
+
+
+def test_run_hornlab_waveguide_rejects_throat_extension(tmp_path: Path) -> None:
+    with pytest.raises(HornlabWaveguideGenerationError, match="Throat.Ext.Length"):
+        run_hornlab_waveguide(
+            config_text="Throat.Ext.Length = 15\nLength = 100",
+            run_root=tmp_path / "runs",
+            case_name="case",
+        )
+
+
+def test_generate_waveguide_falls_back_to_ath_for_throat_extension(tmp_path: Path) -> None:
+    sentinel = object()
+    runner = _RecordingRunner(result=sentinel)
+
+    result = generate_waveguide_mesh(
+        ath_exe=tmp_path / "ath" / "ath.exe",
+        config_text="Throat.Ext.Length = 15\nLength = 100",
+        run_root=tmp_path / "runs",
+        case_name="case",
+        runner=runner,
+    )
+
+    assert len(runner.calls) == 1  # throat extension routes to Ath, not the mesher
+    assert result is sentinel

--- a/tests/test_main_window_mesh_workflow.py
+++ b/tests/test_main_window_mesh_workflow.py
@@ -6,11 +6,22 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from PySide6.QtCore import QByteArray
+
+import blab.ui.main_window as main_window_module
 from blab.ath import AthRunResult
 from blab.config import ChannelConfig, MeshConfig, RadiatorConfig
 from blab.ui.dialogs import MeshDialogEntry
-from blab.ui.main_window import STITCH_FAILURE_MESSAGE, STITCHED_MESH_NAME, MainWindow
-from blab.ui.project_state import AthScriptState
+from blab.ui.main_window import (
+    DEFAULT_DOCK_STATE_B64,
+    OBSOLETE_DOCK_OBJECT_NAMES,
+    STITCH_FAILURE_MESSAGE,
+    STITCHED_MESH_NAME,
+    MainWindow,
+    _dock_state_has_obsolete_object_names,
+)
+from blab.ui.project_state import AthScriptState, scripts_from_payload
+from blab.ui.settings import GuiPreferences
 
 
 def _write_triangle_mesh(path: Path, tag: int = 2) -> None:
@@ -28,6 +39,49 @@ def _write_triangle_mesh(path: Path, tag: int = 2) -> None:
         field_data={"SD1D1001": np.array([tag, 2], dtype=np.int32)},
     )
     meshio.write(path, mesh, file_format="gmsh22", binary=False)
+
+
+def test_default_dock_state_does_not_reference_removed_plots_dock() -> None:
+    dock_state = QByteArray.fromBase64(DEFAULT_DOCK_STATE_B64.encode("ascii"))
+
+    assert not _dock_state_has_obsolete_object_names(dock_state)
+
+
+def test_obsolete_dock_state_detector_finds_legacy_plots_dock() -> None:
+    legacy_state = QByteArray(b"prefix" + OBSOLETE_DOCK_OBJECT_NAMES[0].encode("utf-16-be") + b"suffix")
+
+    assert _dock_state_has_obsolete_object_names(legacy_state)
+
+
+def test_restore_window_state_skips_legacy_plots_dock_layout() -> None:
+    legacy_state = QByteArray(b"prefix" + OBSOLETE_DOCK_OBJECT_NAMES[0].encode("utf-16-be") + b"suffix")
+    removed_keys = []
+    restore_calls = []
+
+    class Settings:
+        def value(self, key):
+            return legacy_state if key == "window/dock_state" else None
+
+        def remove(self, key):
+            removed_keys.append(key)
+
+    class Workspace:
+        def restoreState(self, state):  # noqa: N802 - Qt API shape
+            restore_calls.append(state)
+            return True
+
+    window = MainWindow.__new__(MainWindow)
+    window.settings = Settings()
+    window.workspace = Workspace()
+    window.plot_entries = ()
+    window.restoreGeometry = lambda _geometry: None
+    window._sync_panel_view_action = lambda _dock_id: None
+    window._sync_plot_view_action = lambda _plot_id: None
+
+    MainWindow._restore_window_state(window)
+
+    assert removed_keys == ["window/dock_state"]
+    assert restore_calls == []
 
 
 def test_xy_stitch_candidates_use_reduced_ath_mesh_before_stitching(tmp_path: Path) -> None:
@@ -104,6 +158,402 @@ def test_preview_falls_back_to_unstitched_meshes_when_preview_stitching_fails(tm
     assert "cleared" not in loaded
 
 
+def test_preview_refresh_reports_non_stitch_failures() -> None:
+    loaded = {}
+
+    class PreviewStub:
+        def clear(self) -> None:
+            loaded["cleared"] = True
+
+    class StatusStub:
+        def setText(self, text: str) -> None:
+            loaded["status"] = text
+
+    window = MainWindow.__new__(MainWindow)
+    window.stitch_imported_meshes = False
+    window.preview = PreviewStub()
+    window.status_label = StatusStub()
+    window._last_mesh_preview_error = None
+    window._has_solver_meshes = lambda: True
+    window._solver_mesh_configs = lambda: (_ for _ in ()).throw(ValueError("bad mesh"))
+
+    window._refresh_mesh_preview()
+
+    assert loaded["cleared"] is True
+    assert window._last_mesh_preview_error == "bad mesh"
+    assert loaded["status"] == "Mesh preview failed: bad mesh"
+
+
+def test_generated_result_updates_script_mesh_scale(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    script = AthScriptState(id="script1", name="ath", config_text="")
+    result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "case.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+    emitted = {}
+
+    class SignalStub:
+        def emit(self, reason: str) -> None:
+            emitted["reason"] = reason
+
+    class StatusStub:
+        def setText(self, text: str) -> None:
+            emitted["status"] = text
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_generation_script_id = script.id
+    window.ath_generation_mesh_name = script.mesh_name
+    window.ath_results_by_script_id = {}
+    window.ath_scripts = (script,)
+    window.mesh_state_changed = SignalStub()
+    window.status_label = StatusStub()
+    window._last_mesh_preview_error = None
+    window._apply_saved_source_config_to_result = lambda generated_result, _mesh_name: generated_result
+    window._show_mesh_quality_warning = lambda _result: None
+
+    window._on_ath_generated(result)
+
+    assert window.ath_scripts[0].mesh_scale_factor == 0.001
+    assert emitted["reason"] == "ath_mesh_generated"
+
+
+def test_generation_start_clears_stale_generated_mesh_result(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    script = AthScriptState(
+        id="script1",
+        name="ath",
+        config_text="",
+        output_dir=str(tmp_path),
+        msh_path=str(mesh_path),
+        cleaned_msh_path=str(mesh_path),
+        config_path=str(tmp_path / "case.cfg"),
+    )
+    result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "case.cfg",
+        driven_tag=2,
+        radiators=(),
+        cleaned_msh_path=mesh_path,
+    )
+    emitted = {}
+
+    class SignalStub:
+        def emit(self, reason: str) -> None:
+            emitted["reason"] = reason
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_scripts = (script,)
+    window.ath_results_by_script_id = {script.id: result}
+    window.mesh_state_changed = SignalStub()
+
+    window._clear_generated_result_for_script(script.id, "geometry_generation_started")
+
+    assert window.ath_results_by_script_id == {}
+    assert window.ath_scripts[0].output_dir is None
+    assert window.ath_scripts[0].msh_path is None
+    assert window.ath_scripts[0].cleaned_msh_path is None
+    assert window.ath_scripts[0].config_path is None
+    assert emitted["reason"] == "geometry_generation_started"
+
+
+def test_saved_ath_result_restores_script_mesh_scale(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    script = AthScriptState(
+        id="script1",
+        name="ath",
+        config_text="",
+        output_dir=str(tmp_path),
+        msh_path=str(mesh_path),
+        config_path=str(tmp_path / "case.cfg"),
+        mesh_scale_factor=0.001,
+    )
+    window = MainWindow.__new__(MainWindow)
+
+    result = window._result_from_script_state(script)
+
+    assert result is not None
+
+
+def test_legacy_saved_ath_scale_is_migrated_before_building_solver_meshes(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    script = scripts_from_payload(
+        [
+            {
+                "id": "script1",
+                "name": "ath",
+                "config_text": "",
+                "mesh_scale_factor": 1.0,
+            }
+        ]
+    )[0]
+    result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "case.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+    window = MainWindow.__new__(MainWindow)
+    window.symmetry = "off"
+    window.ath_scripts = (script,)
+    window.ath_results_by_script_id = {script.id: result}
+
+    mesh_configs = window._ath_solver_mesh_configs()
+
+    assert mesh_configs[0].scale_factor == 0.001
+
+
+def test_stale_in_memory_ath_scale_is_repaired_before_building_solver_meshes(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    script = AthScriptState(id="script1", name="ath", config_text="", mesh_scale_factor=1000.0)
+    result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "case.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+    window = MainWindow.__new__(MainWindow)
+    window.symmetry = "off"
+    window.ath_scripts = (script,)
+    window.ath_results_by_script_id = {script.id: result}
+
+    mesh_configs = window._ath_solver_mesh_configs()
+
+    assert mesh_configs[0].scale_factor == 0.001
+
+
+def test_import_config_applies_abec_solve_metadata_to_gui_controls(tmp_path: Path) -> None:
+    config_path = tmp_path / "case.cfg"
+    config_path.write_text(
+        """
+        ABEC.NumFrequencies = 40
+        ABEC.Polars:SPL_H = {
+        Distance = 2
+        MapAngleRange = 0,180,37
+        NormAngle = 0
+        }
+        ABEC.Polars:SPL_V = {
+        Distance = 2
+        Inclination = 90
+        MapAngleRange = 0,180,37
+        NormAngle = 0
+        }
+        ABEC.f1 = 100
+        ABEC.f2 = 20000
+        """,
+        encoding="utf-8",
+    )
+    script = AthScriptState(id="script1", name="ath", config_text="")
+    saved_preferences = []
+    status = {}
+
+    class SpinStub:
+        def __init__(self, minimum: int, maximum: int, value: int):
+            self._minimum = minimum
+            self._maximum = maximum
+            self._value = value
+
+        def minimum(self) -> int:
+            return self._minimum
+
+        def maximum(self) -> int:
+            return self._maximum
+
+        def setValue(self, value: int) -> None:  # noqa: N802 - Qt API shape
+            self._value = int(value)
+
+        def value(self) -> int:
+            return self._value
+
+    class StatusStub:
+        def setText(self, text: str) -> None:
+            status["text"] = text
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_scripts = (script,)
+    window.active_ath_script_id = script.id
+    window.freq_min_spin = SpinStub(20, 20000, 500)
+    window.freq_max_spin = SpinStub(20, 20000, 1000)
+    window.freq_count_spin = SpinStub(3, 200, 3)
+    window.preferences = GuiPreferences(
+        polar_angle_step_deg=30.0,
+        polar_observation_distance_m=1.0,
+        horizontal_normalization_angle=10.0,
+        vertical_normalization_angle=10.0,
+    )
+    window._save_preferences = lambda: saved_preferences.append(window.preferences)
+    window._rebuild_ath_script_tabs = lambda: None
+    window.status_label = StatusStub()
+
+    window._import_config_path(config_path)
+
+    assert window.freq_min_spin.value() == 100
+    assert window.freq_max_spin.value() == 20000
+    assert window.freq_count_spin.value() == 40
+    assert window.preferences.polar_angle_step_deg == pytest.approx(5.0)
+    assert window.preferences.polar_observation_distance_m == 2.0
+    assert window.preferences.horizontal_normalization_angle == 0.0
+    assert window.preferences.vertical_normalization_angle == 0.0
+    assert saved_preferences
+    assert status["text"] == f"Imported {config_path}"
+
+
+def test_import_config_into_script_makes_that_script_active(tmp_path: Path) -> None:
+    config_path = tmp_path / "case.cfg"
+    config_path.write_text("ABEC.NumFrequencies = 40\n", encoding="utf-8")
+    script_a = AthScriptState(id="script1", name="empty", config_text="")
+    script_b = AthScriptState(id="script2", name="loaded", config_text="")
+
+    class SpinStub:
+        def __init__(self, value: int):
+            self._value = value
+
+        def minimum(self) -> int:
+            return 1
+
+        def maximum(self) -> int:
+            return 200
+
+        def setValue(self, value: int) -> None:  # noqa: N802 - Qt API shape
+            self._value = int(value)
+
+    class StatusStub:
+        def setText(self, _text: str) -> None:
+            pass
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_scripts = (script_a, script_b)
+    window.active_ath_script_id = script_a.id
+    window.freq_min_spin = SpinStub(500)
+    window.freq_max_spin = SpinStub(1000)
+    window.freq_count_spin = SpinStub(3)
+    window.preferences = GuiPreferences()
+    window._save_preferences = lambda: None
+    window._rebuild_ath_script_tabs = lambda: None
+    window.status_label = StatusStub()
+
+    window._import_config_path(config_path, script_id=script_b.id)
+
+    assert window.active_ath_script_id == script_b.id
+    assert window.ath_scripts[1].config_text == "ABEC.NumFrequencies = 40\n"
+
+
+def test_solver_solve_settings_fall_back_to_enabled_ath_mesh_config(tmp_path: Path) -> None:
+    mesh_path = tmp_path / "case.msh"
+    _write_triangle_mesh(mesh_path)
+    active_script = AthScriptState(id="script1", name="blank", config_text="")
+    mesh_script = AthScriptState(
+        id="script2",
+        name="generated",
+        config_text="""
+        ABEC.NumFrequencies = 40
+        ABEC.f1 = 100
+        ABEC.f2 = 20000
+        ABEC.Polars:SPL_H = {
+        Distance = 2
+        MapAngleRange = 0,180,37
+        NormAngle = 0
+        }
+        """,
+    )
+    result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "case.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_scripts = (active_script, mesh_script)
+    window.active_ath_script_id = active_script.id
+    window.ath_results_by_script_id = {mesh_script.id: result}
+
+    settings = window._solver_ath_solve_settings()
+
+    assert settings.freq_min_hz == 100.0
+    assert settings.freq_max_hz == 20000.0
+    assert settings.freq_count == 40
+    assert settings.polar_step_deg == pytest.approx(5.0)
+
+
+def test_import_config_links_adjacent_existing_ath_mesh_output(tmp_path: Path) -> None:
+    case_dir = tmp_path / "case"
+    mesh_dir = case_dir / "ABEC_FreeStanding"
+    mesh_dir.mkdir(parents=True)
+    config_path = case_dir / "config.txt"
+    config_path.write_text("ABEC.NumFrequencies = 40\n", encoding="utf-8")
+    msh_path = mesh_dir / "case.msh"
+    _write_triangle_mesh(msh_path)
+
+    script = AthScriptState(
+        id="script1",
+        name="case",
+        config_text="old",
+        output_dir="old",
+        msh_path="old.msh",
+        config_path="old.cfg",
+    )
+    emitted = {}
+
+    class SpinStub:
+        def __init__(self, value: int):
+            self._value = value
+
+        def minimum(self) -> int:
+            return 1
+
+        def maximum(self) -> int:
+            return 200
+
+        def setValue(self, value: int) -> None:  # noqa: N802 - Qt API shape
+            self._value = int(value)
+
+    class StatusStub:
+        def setText(self, text: str) -> None:
+            emitted["status"] = text
+
+    class SignalStub:
+        def emit(self, reason: str) -> None:
+            emitted["reason"] = reason
+
+    window = MainWindow.__new__(MainWindow)
+    window.ath_scripts = (script,)
+    window.active_ath_script_id = script.id
+    window.ath_results_by_script_id = {}
+    window.freq_min_spin = SpinStub(500)
+    window.freq_max_spin = SpinStub(1000)
+    window.freq_count_spin = SpinStub(3)
+    window.preferences = GuiPreferences()
+    window._save_preferences = lambda: None
+    window._rebuild_ath_script_tabs = lambda: None
+    window._apply_saved_source_config_to_result = lambda result, _mesh_name: result
+    window.status_label = StatusStub()
+    window.mesh_state_changed = SignalStub()
+
+    window._import_config_path(config_path)
+
+    result = window.ath_results_by_script_id[script.id]
+    assert result.output_dir == case_dir
+    assert result.msh_path == msh_path
+    assert window.ath_scripts[0].output_dir == str(case_dir)
+    assert window.ath_scripts[0].msh_path == str(msh_path)
+    assert window.ath_scripts[0].config_path == str(config_path)
+    assert window.ath_scripts[0].mesh_scale_factor == 0.001
+    assert emitted["reason"] == "ath_config_imported_with_existing_mesh"
+
+
 def test_stitched_solver_radiators_reference_stitched_mesh(tmp_path: Path) -> None:
     ath_msh = tmp_path / "ath_clean.msh"
     imported_msh = tmp_path / "external_clean.msh"
@@ -145,6 +595,64 @@ def test_stitched_solver_radiators_reference_stitched_mesh(tmp_path: Path) -> No
         ("stitched:SD1D1001", "stitched", 2),
         ("stitched:SD1D1001_mesh2", "stitched", 1),
     ]
+
+
+def test_primary_solver_mesh_scale_uses_primary_mesh_scale() -> None:
+    # The advertised top-level scale must equal the primary mesh's own scale, not
+    # the millimetre default. A metre-unit mesh (scale 1.0) must keep 1.0, or
+    # single-file backends that scale mesh_file by it collapse the model to a
+    # point source (flat directivity at all angles).
+    mesh_configs = (
+        MeshConfig(name="wg", file="wg.msh", scale_factor=1.0),
+        MeshConfig(name="other", file="other.msh", scale_factor=0.001),
+    )
+    assert MainWindow._primary_solver_mesh_scale(mesh_configs) == 1.0
+
+
+def test_primary_solver_mesh_scale_falls_back_to_default() -> None:
+    assert MainWindow._primary_solver_mesh_scale(()) == 0.001
+    assert MainWindow._primary_solver_mesh_scale((MeshConfig(name="wg", file="wg.msh"),)) == 0.001
+
+
+def test_ensure_ath_runtime_config_creates_missing_companion_cfg(tmp_path: Path, monkeypatch) -> None:
+    ath_dir = tmp_path / "ath"
+    ath_dir.mkdir()
+    (ath_dir / "ath.exe").write_text("", encoding="utf-8")
+    gmsh_exe = tmp_path / "gmsh" / "gmsh.exe"
+    gmsh_exe.parent.mkdir()
+    gmsh_exe.write_text("", encoding="utf-8")
+    output_root = tmp_path / "runs" / "ath_output"
+
+    monkeypatch.setattr(main_window_module, "ATH_BUNDLE_DIR", ath_dir)
+    monkeypatch.setattr(main_window_module, "GMSH_BUNDLE_EXE", gmsh_exe)
+    monkeypatch.setattr(main_window_module, "ATH_OUTPUT_ROOT", output_root)
+
+    window = MainWindow.__new__(MainWindow)
+    window._ensure_ath_runtime_config()
+
+    cfg_text = (ath_dir / "ath.cfg").read_text(encoding="utf-8")
+    assert f'OutputRootDir = "{output_root.resolve()}"' in cfg_text
+    assert f'MeshCmd = "{gmsh_exe.resolve()} %f -"' in cfg_text
+
+
+def test_native_open_edge_check_stays_strict_for_closed_generated_meshes() -> None:
+    window = MainWindow.__new__(MainWindow)
+    window.symmetry = "xy"
+    window._enabled_ath_results = lambda: (
+        (AthScriptState(id="script1", name="ath", config_text="mode = freestanding\n"), object()),
+    )
+
+    assert window._native_check_open_edges_for_solver() is True
+
+
+def test_native_open_edge_check_opts_out_for_bare_generated_meshes() -> None:
+    window = MainWindow.__new__(MainWindow)
+    window.symmetry = "xy"
+    window._enabled_ath_results = lambda: (
+        (AthScriptState(id="script1", name="ath", config_text="Mesh.Mode = bare\n"), object()),
+    )
+
+    assert window._native_check_open_edges_for_solver() is False
 
 
 def test_solver_channels_include_radiator_default_channel_when_missing() -> None:

--- a/tests/test_mesh_config_dialog.py
+++ b/tests/test_mesh_config_dialog.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication
+
+from blab.ui.dialogs import MeshConfigDialog, MeshDialogEntry
+
+_APP = QApplication.instance() or QApplication([])
+
+
+def test_locked_generated_mesh_scale_is_not_editable() -> None:
+    dialog = MeshConfigDialog(
+        (
+            MeshDialogEntry(name="ath", source_file="ath.msh", scale_factor=0.001, locked=True),
+            MeshDialogEntry(name="cabinet", source_file="cabinet.msh", scale_factor=0.001),
+        )
+    )
+    try:
+        assert not dialog.scale_widgets[0].isEnabled()
+        assert dialog.scale_widgets[1].isEnabled()
+    finally:
+        dialog.close()

--- a/tests/test_mesh_preview.py
+++ b/tests/test_mesh_preview.py
@@ -5,9 +5,11 @@ import pytest
 
 pytest.importorskip("PySide6")
 
+from blab.config import MeshConfig
 from blab.ui.mesh_preview import (
     PREVIEW_HOME_CAMERA_DIRECTION,
     PREVIEW_HOME_VIEW_UP,
+    MeshPreview,
     _dimensions_lwh_mm,
     _mesh_stats_label,
     _mirrored_triangle_images_for_preview,
@@ -37,6 +39,42 @@ def test_preview_status_labels_do_not_force_panel_width() -> None:
     assert "self.hover_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)" in source
     assert "self.total_elements_label.setMinimumWidth(0)" in source
     assert "self.total_elements_label.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)" in source
+
+
+def test_load_mesh_configs_requests_render_after_preview_update() -> None:
+    calls = []
+
+    class ViewerStub:
+        def clear(self) -> None:
+            calls.append("clear")
+
+        def render(self) -> None:
+            calls.append("render")
+
+        def update(self) -> None:
+            calls.append("update")
+
+    class LabelStub:
+        def setText(self, text: str) -> None:
+            calls.append(f"label:{text}")
+
+    preview = MeshPreview.__new__(MeshPreview)
+    preview.viewer = ViewerStub()
+    preview._actor_surface_labels = {}
+    preview.hover_label = LabelStub()
+    preview.total_elements_label = LabelStub()
+    preview._camera_position = lambda: None
+    preview._add_msh_mesh = lambda _mesh_cfg, **_kwargs: (
+        3,
+        np.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.0, 0.2, 0.3]]),
+    )
+    preview._add_orientation_guides = lambda _points: None
+    preview._restore_camera_or_reset = lambda _camera_position: None
+
+    preview.load_mesh_configs((MeshConfig(name="ath", file="unused.msh"),))
+
+    assert "render" in calls
+    assert "update" in calls
 
 
 def test_preview_axis_length_scales_with_mesh_bounds() -> None:

--- a/tests/test_postprocess_plotting.py
+++ b/tests/test_postprocess_plotting.py
@@ -130,6 +130,75 @@ def test_prepare_visualization_data_can_skip_normalization_and_auto_span() -> No
     assert np.allclose(dataset["horizontal_spl_norm_db"], horizontal)
 
 
+def test_prepare_visualization_data_expands_fixed_span_when_everything_would_clip() -> None:
+    freqs = np.array([200.0, 1000.0], dtype=np.float32)
+    angles = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    horizontal = np.array([[21.2, 28.4, 22.5], [24.0, 30.1, 25.0]], dtype=np.float32)
+    vertical = horizontal - 2.0
+
+    dataset = prepare_visualization_data_from_arrays(
+        freq_hz=freqs,
+        polar_angle_deg=angles,
+        horizontal_spl_norm_db=horizontal,
+        vertical_spl_norm_db=vertical,
+        impedance_freq_hz=freqs,
+        impedance_radiator_names=np.array(["throat"]),
+        impedance_real=np.ones((1, 2), dtype=np.float32),
+        impedance_imag=np.zeros((1, 2), dtype=np.float32),
+        cfg=PrepConfig(
+            angle_samples=None,
+            freq_samples=None,
+            octave_smoothing=None,
+            normalize_polar=False,
+            auto_db_span=False,
+            min_db=-30.0,
+            max_db=0.0,
+        ),
+    )
+
+    assert dataset["clip_min_db"] == 19.0
+    assert dataset["clip_max_db"] == 31.0
+    assert np.nanmin(dataset["horizontal_isobar_db"]) < np.nanmax(dataset["horizontal_isobar_db"])
+
+
+def test_prepare_visualization_data_expands_narrow_fixed_span_for_visible_isobar() -> None:
+    freqs = np.array([500.0, 1000.0, 2000.0], dtype=np.float32)
+    angles = np.array([-90.0, -45.0, 0.0, 45.0, 90.0], dtype=np.float32)
+    horizontal = np.array(
+        [
+            [-1.4, -0.7, 0.2, -0.6, -1.2],
+            [-2.2, -1.0, 0.4, -0.8, -1.8],
+            [-2.8, -1.4, 0.1, -1.1, -2.3],
+        ],
+        dtype=np.float32,
+    )
+    vertical = horizontal - 0.4
+
+    dataset = prepare_visualization_data_from_arrays(
+        freq_hz=freqs,
+        polar_angle_deg=angles,
+        horizontal_spl_norm_db=horizontal,
+        vertical_spl_norm_db=vertical,
+        impedance_freq_hz=freqs,
+        impedance_radiator_names=np.array(["throat"]),
+        impedance_real=np.ones((1, 3), dtype=np.float32),
+        impedance_imag=np.zeros((1, 3), dtype=np.float32),
+        cfg=PrepConfig(
+            angle_samples=None,
+            freq_samples=None,
+            octave_smoothing=None,
+            normalize_polar=False,
+            auto_db_span=False,
+            min_db=-30.0,
+            max_db=0.0,
+        ),
+    )
+
+    assert dataset["clip_min_db"] == -5.0
+    assert dataset["clip_max_db"] == 1.0
+    assert np.nanmin(dataset["horizontal_isobar_db"]) < np.nanmax(dataset["horizontal_isobar_db"])
+
+
 def test_prepare_visualization_data_preserves_raw_spl_for_on_axis_response() -> None:
     freqs = np.array([200.0, 1000.0], dtype=np.float32)
     angles = np.array([-90.0, 0.0, 90.0], dtype=np.float32)

--- a/tests/test_project_state.py
+++ b/tests/test_project_state.py
@@ -25,6 +25,59 @@ def test_scripts_from_payload_falls_back_to_default_script() -> None:
 
     assert len(scripts) == 1
     assert scripts[0].config_text == "legacy"
+    assert scripts[0].mesh_scale_factor == 0.001
+
+
+def test_ath_script_payload_without_scale_uses_millimetre_mesh_scale() -> None:
+    restored = script_from_payload({"id": "script1", "name": "ath", "config_text": ""})
+
+    assert restored is not None
+    assert restored.mesh_scale_factor == 0.001
+
+
+def test_ath_script_payload_normalizes_legacy_metre_scale_to_millimetres() -> None:
+    restored = script_from_payload(
+        {
+            "id": "script1",
+            "name": "ath",
+            "config_text": "",
+            "mesh_scale_factor": 1.0,
+        }
+    )
+
+    assert restored is not None
+    assert restored.mesh_scale_factor == 0.001
+
+
+def test_ath_script_payload_clamps_custom_scale_to_millimetres() -> None:
+    restored = script_from_payload(
+        {
+            "id": "script1",
+            "name": "ath",
+            "config_text": "",
+            "mesh_scale_factor": 1000.0,
+        }
+    )
+
+    assert restored is not None
+    assert restored.mesh_scale_factor == 0.001
+
+
+def test_ath_script_payload_serializes_stale_scale_as_millimetres() -> None:
+    script = script_from_payload(
+        {
+            "id": "script1",
+            "name": "ath",
+            "config_text": "",
+            "mesh_scale_factor": 0.001,
+        }
+    )
+    assert script is not None
+    stale_script = replace_script((script,), script.id, mesh_scale_factor=1000.0)[0]
+
+    payload = script_to_payload(stale_script)
+
+    assert payload["mesh_scale_factor"] == 0.001
 
 
 def test_unique_script_name_avoids_existing_names() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -57,6 +57,7 @@ def test_simulation_config_round_trips_through_wire_dict() -> None:
         spherical_sampling_enabled=True,
         spherical_sampling_points=32,
         symmetry="xy",
+        native_check_open_edges=False,
     )
 
     restored = simulation_config_from_dict(simulation_config_to_dict(config))
@@ -71,6 +72,14 @@ def test_simulation_config_round_trips_through_wire_dict() -> None:
     assert restored.channels[0].lpf.frequency_hz == 20000.0
     assert restored.spherical_sampling_enabled is True
     assert restored.symmetry == "xy"
+    assert restored.native_check_open_edges is False
+
+
+def test_simulation_config_defaults_open_edge_check_on_for_old_payloads() -> None:
+    # A payload from before the field existed must restore to the strict default.
+    payload = simulation_config_to_dict(SimulationConfig(mesh_file="m.msh"))
+    del payload["native_check_open_edges"]
+    assert simulation_config_from_dict(payload).native_check_open_edges is True
 
 
 def test_frequency_result_round_trips_through_wire_dict() -> None:

--- a/tests/test_solver_backends.py
+++ b/tests/test_solver_backends.py
@@ -49,6 +49,8 @@ def test_solver_backend_registry_keeps_legacy_ids_available() -> None:
     assert normalize_backend_id("beat_rocm") == "beat_rocm"
     assert normalize_backend_id("rocm") == "beat_rocm"
     assert normalize_backend_id("amdgpu") == "beat_rocm"
+    assert normalize_backend_id("metal") == "hornlab_metal"
+    assert normalize_backend_id("hornlab") == "hornlab_metal"
     assert JuliaLocalBackend is BeatEngineBackend
     assert BeatEngineRocmBackend.beat_engine_backend == "rocm"
     assert BemppServerBackend is HttpServerBackend
@@ -59,6 +61,7 @@ def test_solver_backend_registry_keeps_legacy_ids_available() -> None:
     assert backend_info("beat_cuda").capabilities.supports_symmetry is True
     assert backend_info("beat_cpu").capabilities.supports_symmetry is True
     assert backend_info("beat_rocm").capabilities.supports_symmetry is True
+    assert backend_info("hornlab_metal").label == "HornLab Metal BEM"
     assert "beat_cuda" in {info.backend_id for info in available_backend_infos()}
     assert "beat_cpu" in {info.backend_id for info in available_backend_infos()}
     assert "beat_rocm" in {info.backend_id for info in available_backend_infos()}
@@ -112,6 +115,12 @@ def test_server_and_julia_backend_factories_expose_contract() -> None:
     assert BeatEngineBackend().julia_project == DEFAULT_BEAT_ENGINE_CUDA_PROJECT
     assert BeatEngineBackend(beat_engine_backend="cpu").julia_project == DEFAULT_BEAT_ENGINE_CPU_PROJECT
     assert BeatEngineBackend(beat_engine_backend="rocm").julia_project == DEFAULT_BEAT_ENGINE_ROCM_PROJECT
+
+    if backend_info("hornlab_metal").available:
+        hornlab_backend = create_backend("hornlab_metal", server_url="http://ignored.example")
+        assert hornlab_backend.backend_id == "hornlab_metal"
+        assert hornlab_backend.capabilities.supports_symmetry is True
+        assert hornlab_backend.capabilities.is_remote is False
 
 
 def test_server_health_supports_symmetry_reads_capability_payload() -> None:

--- a/tests/test_ui_plot_classes.py
+++ b/tests/test_ui_plot_classes.py
@@ -399,6 +399,9 @@ def test_isobar_canvas_reuses_heatmap_artist_between_grid_changes() -> None:
     assert "LinearSegmentedColormap.from_list" in isobar_block
     assert "Normalize(vmin=clip_min_db, vmax=clip_max_db)" in isobar_block
     assert "BoundaryNorm(boundaries, cmap.N)" in isobar_block
+    assert "data_span_db = 0.0 if finite.size == 0 else float(np.max(finite) - np.min(finite))" in isobar_block
+    assert "discrete_colors = contour_step_db <= 0.0 or data_span_db >= 2.0 * contour_step_db" in isobar_block
+    assert "discrete=discrete_colors" in isobar_block
     assert "ScalarMappable(norm=norm, cmap=cmap)" in isobar_block
     assert "self.figure.add_axes" in isobar_block
     assert "cax=self._colorbar_axes" in isobar_block

--- a/tests/test_ui_source_channel_config.py
+++ b/tests/test_ui_source_channel_config.py
@@ -107,6 +107,47 @@ def test_apply_saved_imported_source_config_ignores_generated_meshes() -> None:
     )
 
 
+def test_apply_saved_imported_source_config_defaults_abec_driven_surface() -> None:
+    radiators = apply_saved_imported_source_config(
+        surface_tags={
+            "waveguide:Rigid": ("waveguide", 1),
+            "waveguide:SD1D1001": ("waveguide", 2),
+        },
+        generated_mesh_names={"ath"},
+        existing_radiators=(),
+        config_by_name={},
+    )
+
+    assert radiators == (
+        RadiatorConfig(
+            name="waveguide:SD1D1001",
+            mesh="waveguide",
+            tag=2,
+            channel="main",
+        ),
+    )
+
+
+def test_apply_saved_imported_source_config_defaults_complex_abec_surfaces() -> None:
+    radiators = apply_saved_imported_source_config(
+        surface_tags={
+            "driver:SD1D1001": ("driver", 11),
+            "driver:SD1D1002": ("driver", 12),
+            "driver:SD1D1003": ("driver", 13),
+            "driver:Rigid": ("driver", 14),
+        },
+        generated_mesh_names=set(),
+        existing_radiators=(),
+        config_by_name={},
+    )
+
+    assert [(radiator.name, radiator.mesh, radiator.tag, radiator.level_db) for radiator in radiators] == [
+        ("driver:SD1D1001", "driver", 11, -12.0),
+        ("driver:SD1D1002", "driver", 12, -2.5),
+        ("driver:SD1D1003", "driver", 13, 0.0),
+    ]
+
+
 def test_channels_for_solver_radiators_adds_missing_channel_names() -> None:
     channels = channels_for_solver_radiators(
         (ChannelConfig(name="LF"),),


### PR DESCRIPTION
## Summary

- Add an optional native HornLab waveguide mesher path with Ath/Wine fallback for unsupported geometry.
- Register the optional HornLab Metal BEM backend and carry the native open-edge guard setting through solve requests.
- Improve macOS mesh workflow handling, including fresh `ath.cfg` regeneration, space-free Gmsh staging, imported mesh/source config refresh, and Ath config solve metadata parsing.
- Add focused tests for the new mesher, solver backend, project, plotting, and mesh workflow behavior.

## Validation

- `git diff --check`
- `.venv/bin/ruff check src tests`
- `QT_QPA_PLATFORM=offscreen .venv/bin/python -m pytest -q` (`246 passed`, one dependency deprecation warning)
