### PR TITLE
Improve macOS support with the HornLab waveguide mesher and Metal solver backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ While not required, if modeling in Autodesk Fusion, the [Fusion2Msh](https://git
 
 Boundary Lab currently has five selectable BEM solver backends in application
 preferences: Server, BEAT Engine Nvidia CUDA, BEAT Engine CPU, BEAT Engine AMD
-ROCm, and Bempp OpenCL CPU.
+ROCm, and Bempp OpenCL CPU. Apple Silicon macOS installs also offer HornLab Metal
+BEM (see [macOS HornLab Integration](docs/macOS%20HornLab%20Integration.md)).
 
 ### BEAT Engine CUDA GPU Solver Requirements
 
@@ -88,6 +89,13 @@ From the repository root run:
 ```bash
 python -m pip install -e ".[gui]"
 ```
+
+On macOS and Linux this also installs the HornLab waveguide mesher, which
+generates supported OSSE/R-OSSE geometry natively instead of running Ath through
+Wine, and on Apple Silicon the HornLab Metal BEM backend. Unsupported Ath
+geometry still falls back to Ath/Wine. See
+[macOS HornLab Integration](docs/macOS%20HornLab%20Integration.md). Windows
+installs are unchanged.
 
 ## Run The GUI
 
@@ -143,6 +151,7 @@ For Docker image deployment with the BEAT Engine CUDA solver, see
 - [CUDA Server Docker Image](docs/Docker.md)
 - [Model Assumptions](docs/Model%20Assumptions.md)
 - [Inputs and Outputs](docs/Inputs%20and%20Outputs.md)
+- [macOS HornLab Integration](docs/macOS%20HornLab%20Integration.md)
 - [Advanced CLI workflow](docs/advanced/cli-workflow.md)
 - [BEAT Engine Core](docs/advanced/beat-engine-core.md)
 - [BEAT Engine CPU](docs/advanced/beat-engine-CPU.md)

--- a/docs/macOS HornLab Integration.md
+++ b/docs/macOS HornLab Integration.md
@@ -1,0 +1,75 @@
+# macOS HornLab Integration
+
+Boundary Lab runs Ath through Wine on macOS and Linux. Two optional HornLab
+packages remove that dependency for the geometry families they support and add a
+native Apple Silicon solver backend. Windows installs are unaffected.
+
+## What Gets Installed
+
+`python -m pip install -e ".[gui]"` installs, from pinned public GitHub
+revisions:
+
+| Package | Installed on | Purpose |
+| --- | --- | --- |
+| [`hornlab-waveguide-mesher`](https://github.com/m3gnus/hornlab-waveguide-mesher) | any non-Windows platform | Native OSSE/R-OSSE waveguide meshing without Wine or Ath |
+| [`hornlab-metal-bem`](https://github.com/m3gnus/hornlab-metal-bem) | Apple Silicon macOS | `HornLab Metal BEM` solver backend |
+
+No sibling HornLab checkout is required. Verify an installation with:
+
+```bash
+python -c "import hornlab_mesher; print('HornLab mesher ready')"
+python -c "import hornlab_metal_bem; print('HornLab Metal ready')"
+```
+
+The Metal package ships a Swift source fallback, so a precompiled `.metallib` is
+not required. Building the optional precompiled library needs a Metal-capable
+Xcode toolchain.
+
+## Waveguide Meshing
+
+Ath geometry generation first tries the HornLab mesher, then falls back to
+Ath/Wine. Both paths return the same `AthRunResult`: the mesher's raw mesh is
+handed to Boundary Lab's shared cleaning and mirroring stage, so cleaned,
+reduced, and expanded artifacts are produced exactly as they are for Ath.
+
+Boundary Lab routes a config to Ath instead when:
+
+- `Throat.Ext.Length` requests a throat extension tube. The pinned mesher builds
+  OSSE and R-OSSE extensions, but Boundary Lab has no test pinning that geometry
+  against Ath, and older mesher releases silently shrank the horn.
+- `Source.Contours`, `LFSource.*`, or `Source.Velocity.*` define a multi-source
+  model. The mesher builds only the single throat source.
+- `Mesh.SubdomainSlices`/`Mesh.InterfaceOffset` appear on a free-standing model
+  (`ABEC.SimType = 2`). Ath builds a two-subdomain model there; the mesher
+  rejects that topology rather than silently building a different one.
+- The mesher is not installed, or fails for any other reason.
+
+If the mesher reports different quadrant coverage than `Mesh.Quadrants` implies,
+the run is routed to Ath rather than mirrored against the wrong axes.
+
+Each mesher-generated run writes `hornlab_mesher.json` next to the mesh,
+recording the mesher version, formula, mode, units, quadrants, and element
+counts, so a run's geometry can be reproduced later.
+
+## HornLab Metal BEM Backend
+
+The backend is registered as `hornlab_metal` (aliases: `hornlab`, `metal`,
+`apple_metal`) and is listed only when `hornlab-metal-bem` is importable and
+reports Apple Silicon support. Its package version is recorded in each run's
+solve provenance.
+
+Two behavioural notes:
+
+- The Metal solver has no Burton-Miller operator. Its adapter maps that
+  robustness request onto the solver's complex-wavenumber formulation.
+- The solver's open-edge guard requires every open edge of a mirror-reduced mesh
+  to lie on a symmetry plane. An open-mouth (bare) horn's mouth rim is a real
+  free edge, so Boundary Lab clears `native_check_open_edges` for generated bare
+  waveguides and keeps the strict check everywhere else.
+
+## Known Limits
+
+- The mesher is not a full Ath replacement; unsupported geometry still needs Wine
+  and Ath.
+- The Metal backend is Apple Silicon only. Intel Macs use the existing CPU
+  backends.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ requires-python = ">=3.11"
 dependencies = [
   "bempp-cl",
   "gmsh",
+  # HornLab integrations for platforms where Ath needs Wine. Windows installs are
+  # unaffected: pip skips both markers, so no extra download happens there.
+  "hornlab-waveguide-mesher @ git+https://github.com/m3gnus/hornlab-waveguide-mesher.git@50a8d7e1ae47253e01d80bd36a13fbec99e9624a ; platform_system != 'Windows'",
+  "hornlab-metal-bem @ git+https://github.com/m3gnus/hornlab-metal-bem.git@585ea197b89c335aba6a2060c294bf10b0929fa2 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
   "matplotlib",
   "meshio",
   "numpy",
@@ -31,6 +35,10 @@ gui = [
 
 [project.scripts]
 blab = "blab.cli:main"
+
+[tool.hatch.metadata]
+# Required for the direct git references above.
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/blab"]

--- a/src/blab/ath.py
+++ b/src/blab/ath.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -365,6 +365,396 @@ def run_ath(
         timeout_s=timeout_s,
         status_callback=status_callback,
     )
+
+
+class HornlabWaveguideGenerationError(RuntimeError):
+    """Raised when the HornLab waveguide mesher cannot generate a mesh."""
+
+
+HORNLAB_RESULT_PREFIX = "HORNLAB_RESULT "
+HORNLAB_PROVENANCE_FILENAME = "hornlab_mesher.json"
+# Quadrant coverage the mesher reports, expressed as the mirror axes Boundary Lab
+# expands. Mirrors ath_mirror_axes_from_config_text, which reads the same Ath key.
+HORNLAB_QUADRANT_MIRROR_AXES = {
+    "1": ("x", "y"),
+    "14": ("x",),
+    "1234": (),
+}
+
+_HORNLAB_MESHER_BUILD_SCRIPT = """
+import json
+import sys
+from importlib import metadata
+from pathlib import Path
+
+from hornlab_mesher import build_from_config, load_config
+
+config = load_config(Path(sys.argv[1]))
+# Boundary Lab treats every Ath-family mesh as millimetres (matching real Ath
+# output), so request millimetre output rather than the mesher's default metres.
+# The project's mesh scale factor then applies uniformly.
+mesh_section = config.get("mesh")
+if not isinstance(mesh_section, dict):
+    mesh_section = {}
+    config["mesh"] = mesh_section
+mesh_section["scale_to_metres"] = False
+result = build_from_config(config, Path(sys.argv[2])).as_dict()
+try:
+    result["mesher_version"] = metadata.version("hornlab-waveguide-mesher")
+except metadata.PackageNotFoundError:
+    result["mesher_version"] = "unknown"
+print("HORNLAB_RESULT " + json.dumps(result))
+""".strip()
+
+
+class HornlabMesherRunner:
+    """Small cancellable subprocess wrapper around the HornLab waveguide mesher."""
+
+    def __init__(self) -> None:
+        self._process: subprocess.Popen[str] | None = None
+        self._cancel_requested = False
+
+    def run(self, config_path: Path, msh_path: Path, *, timeout_s: float | None = None) -> dict[str, object]:
+        self._cancel_requested = False
+        command = [sys.executable, "-c", _HORNLAB_MESHER_BUILD_SCRIPT, str(config_path), str(msh_path)]
+        self._process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            stdout, stderr = self._process.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            self.stop()
+            raise
+        finally:
+            process = self._process
+            self._process = None
+
+        if self._cancel_requested:
+            raise AthCancelledError("HornLab mesh generation cancelled")
+
+        returncode = 0 if process is None else process.returncode
+        if returncode == 0:
+            return _parse_hornlab_mesher_result(stdout)
+
+        if _hornlab_mesher_missing(stderr):
+            raise HornlabWaveguideGenerationError(
+                "HornLab waveguide mesher is not installed. Install hornlab-waveguide-mesher "
+                "or install Wine so Boundary Lab can run Ath."
+            )
+        raise RuntimeError(
+            _subprocess_failure_details(subprocess.CompletedProcess(command, returncode, stdout, stderr))
+        )
+
+    def stop(self) -> None:
+        self._cancel_requested = True
+        process = self._process
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5.0)
+
+
+def _hornlab_mesher_missing(details: str) -> bool:
+    return "ModuleNotFoundError" in details and (
+        "No module named 'hornlab_mesher'" in details or 'No module named "hornlab_mesher"' in details
+    )
+
+
+def _subprocess_failure_details(completed: subprocess.CompletedProcess[str]) -> str:
+    output = (completed.stderr or "").strip() or (completed.stdout or "").strip()
+    if not output:
+        return f"process exited with code {completed.returncode}"
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    return lines[-1] if lines else output
+
+
+def _parse_hornlab_mesher_result(stdout: str) -> dict[str, object]:
+    result_lines = [
+        line.removeprefix(HORNLAB_RESULT_PREFIX)
+        for line in stdout.splitlines()
+        if line.startswith(HORNLAB_RESULT_PREFIX)
+    ]
+    if len(result_lines) != 1:
+        raise RuntimeError("HornLab mesher did not emit a single structured result line.")
+    try:
+        result = json.loads(result_lines[0])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"HornLab mesher emitted invalid structured result JSON: {exc}") from exc
+    if not isinstance(result, dict):
+        raise RuntimeError("HornLab mesher structured result was not a JSON object.")
+    return result
+
+
+_THROAT_EXT_LENGTH_RE = re.compile(
+    r"^[^\S\n]*Throat\.Ext\.Length[^\S\n]*=[^\S\n]*([^;#\n]*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Multi-source keys/blocks the mesher cannot build. ``Source.VelocityProfile`` is a
+# supported import and must NOT match, hence the mandatory dot after ``Velocity``.
+_MULTI_SOURCE_RE = re.compile(
+    r"^[^\S\n]*(?:Source\.Contours|LFSource[\w.]*|Source\.Velocity(?:\.[\w.]*)?)[^\S\n]*=",
+    re.IGNORECASE | re.MULTILINE,
+)
+_SIM_TYPE_RE = re.compile(
+    r"^[^\S\n]*ABEC\.SimType[^\S\n]*=[^\S\n]*([^;#\n]*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ENCLOSURE_RE = re.compile(
+    r"^[^\S\n]*Mesh\.Enclosure(?:\.[\w.]+)?[^\S\n]*=",
+    re.IGNORECASE | re.MULTILINE,
+)
+_SUBDOMAIN_SLICES_RE = re.compile(
+    r"^[^\S\n]*Mesh\.SubdomainSlices[^\S\n]*=[^\S\n]*([^;#\n]*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_INTERFACE_OFFSET_RE = re.compile(
+    r"^[^\S\n]*Mesh\.InterfaceOffset[^\S\n]*=[^\S\n]*([^;#\n]*)",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _last_config_value(regex: re.Pattern[str], config_text: str) -> str | None:
+    """Last assignment wins, matching the Ath/mesher parsers for duplicate keys."""
+    values = regex.findall(config_text)
+    return values[-1].strip() if values else None
+
+
+def _throat_ext_requested(config_text: str) -> bool:
+    match = _THROAT_EXT_LENGTH_RE.search(config_text)
+    if match is None:
+        return False
+    value = match.group(1).strip()
+    if not value:
+        return False
+    try:
+        return float(value) != 0.0
+    except ValueError:
+        return True  # a non-numeric (expression) extension length -- assume non-zero
+
+
+def _is_freestanding_config(config_text: str) -> bool:
+    """True for a free-standing build: ``ABEC.SimType = 2`` without ``Mesh.Enclosure``.
+
+    Matches the mesher's text-import topology rules: SimType defaults to 1 (infinite
+    baffle), a ``Mesh.Enclosure`` section implies an enclosure build, and invalid
+    SimType values make the mesher itself fail loudly (which routes to Ath anyway).
+    """
+    if _ENCLOSURE_RE.search(config_text) is not None:
+        return False
+    sim_type = _last_config_value(_SIM_TYPE_RE, config_text)
+    if sim_type is None:
+        return False
+    try:
+        return float(sim_type) == 2.0
+    except ValueError:
+        return False
+
+
+def _requests_subdomain_interfaces(config_text: str) -> bool:
+    slices = _last_config_value(_SUBDOMAIN_SLICES_RE, config_text)
+    if slices:
+        return True
+    offset = _last_config_value(_INTERFACE_OFFSET_RE, config_text)
+    if not offset:
+        return False
+    for part in offset.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            if float(part) > 0.0:
+                return True
+        except ValueError:
+            return True  # a non-numeric (expression) offset -- assume a real request
+    return False
+
+
+def _mesher_unsupported_reason(config_text: str) -> str | None:
+    """Return a reason to skip the HornLab mesher and go straight to Ath.
+
+    Routes configs the mesher cannot (or, on older releases, silently could not)
+    build to the Ath toolchain up front -- a clearer message than a mesher subprocess
+    failure, and no wasted subprocess:
+
+    - ``Throat.Ext.Length``: the pinned mesher builds OSSE and R-OSSE throat
+      extensions, but Boundary Lab has no test that pins their geometry against Ath,
+      and older mesher releases silently shrank the horn (16-32% mouth-radius error).
+      Keep routing throat extensions to Ath until that equivalence is covered here.
+      ``Throat.Ext.Angle`` alone is fine.
+    - Multi-source models (``Source.Contours`` membranes, secondary ``LFSource.*``
+      drivers, ``Source.Velocity`` profiles): the mesher only builds the single
+      cap/disc throat source. Current mesher versions reject these at parse time;
+      older ones meshed a default cap source, silently dropping the rest of the
+      crossover model (e.g. the bundled 2-way example's dome and woofer).
+    - ``Mesh.SubdomainSlices``/``Mesh.InterfaceOffset`` on a free-standing model:
+      Ath builds a two-subdomain free-standing model; the mesher supports subdomain
+      interfaces only for enclosure and infinite-baffle builds and rejects the rest
+      at build time.
+    """
+    if _throat_ext_requested(config_text):
+        return (
+            "Throat.Ext.Length (throat extension tube) is routed to Ath until Boundary Lab "
+            "covers the mesher's throat-extension geometry against Ath."
+        )
+    if _MULTI_SOURCE_RE.search(config_text) is not None:
+        return (
+            "Source.Contours/LFSource/Source.Velocity define a multi-source model; the "
+            "HornLab mesher only builds the single throat source, so using Ath instead."
+        )
+    if _is_freestanding_config(config_text) and _requests_subdomain_interfaces(config_text):
+        return (
+            "Mesh.SubdomainSlices/Mesh.InterfaceOffset on a free-standing model needs Ath's "
+            "two-subdomain construction, which the HornLab mesher does not build; using Ath instead."
+        )
+    return None
+
+
+def _verify_hornlab_quadrants(mesher_result: Mapping[str, object], mirror_axes: tuple[str, ...]) -> None:
+    """Fail loudly when the built quadrant disagrees with the config's Mesh.Quadrants.
+
+    Boundary Lab mirrors the mesh back to the full model using the axes it reads from
+    the config, so a mesher that built a different quadrant would silently produce a
+    different acoustic model.
+    """
+    quadrants = mesher_result.get("quadrants")
+    if quadrants is None:
+        return
+    built_axes = HORNLAB_QUADRANT_MIRROR_AXES.get(str(quadrants))
+    if built_axes is None:
+        raise HornlabWaveguideGenerationError(
+            f"HornLab mesher built unsupported quadrant coverage {quadrants!r}; using Ath instead."
+        )
+    if built_axes != mirror_axes:
+        raise HornlabWaveguideGenerationError(
+            f"HornLab mesher built quadrants {quadrants!r} but the config implies mirror axes "
+            f"{mirror_axes or ('none',)}; using Ath instead."
+        )
+
+
+def _write_hornlab_provenance(output_dir: Path, mesher_result: Mapping[str, object]) -> None:
+    """Record which mesher build produced this run's geometry."""
+    payload = {
+        key: mesher_result.get(key)
+        for key in ("mesher_version", "formula", "mode", "units", "quadrants", "n_vertices", "n_triangles")
+    }
+    (output_dir / HORNLAB_PROVENANCE_FILENAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_hornlab_waveguide(
+    *,
+    config_text: str,
+    run_root: Path,
+    case_name: str = "waveguide",
+    runner: HornlabMesherRunner | None = None,
+    timeout_s: float | None = None,
+) -> AthRunResult:
+    """Generate an Ath-compatible mesh with the HornLab waveguide mesher.
+
+    Produces the same :class:`AthRunResult` artifacts as the Ath toolchain by handing
+    the mesher's raw mesh to the shared cleaning/mirroring stage.
+    """
+    reason = _mesher_unsupported_reason(config_text)
+    if reason is not None:
+        raise HornlabWaveguideGenerationError(reason)
+
+    mirror_axes = ath_mirror_axes_from_config_text(config_text)
+    run_root = Path(run_root)
+    run_root.mkdir(parents=True, exist_ok=True)
+    run_root = run_root.resolve()
+    output_dir = run_root / case_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config_path = output_dir / f"{case_name}.cfg"
+    config_path.write_text(config_text, encoding="utf-8")
+    raw_msh_path = output_dir / f".{case_name}_hornlab_raw.msh"
+
+    try:
+        mesher_result = (runner or HornlabMesherRunner()).run(config_path, raw_msh_path, timeout_s=timeout_s)
+        _verify_hornlab_quadrants(mesher_result, mirror_axes)
+        raw_mesh = meshio.read(raw_msh_path)
+    except (AthCancelledError, HornlabWaveguideGenerationError):
+        raise
+    except Exception as exc:
+        raise HornlabWaveguideGenerationError(
+            "HornLab waveguide mesher could not generate this geometry. It supports OSSE/R-OSSE "
+            f"waveguide configs with ABEC-compatible physical tags. Details: {exc}"
+        ) from exc
+    finally:
+        raw_msh_path.unlink(missing_ok=True)
+
+    _write_hornlab_provenance(output_dir, mesher_result)
+    return build_ath_mesh_artifacts(
+        raw_mesh,
+        output_dir=output_dir,
+        case_name=case_name,
+        config_path=config_path,
+        mirror_axes=mirror_axes,
+    )
+
+
+def generate_waveguide_mesh(
+    *,
+    ath_exe: Path,
+    config_text: str,
+    run_root: Path,
+    case_name: str = "waveguide",
+    runner: AthProcessRunner | None = None,
+    mesher_runner: HornlabMesherRunner | None = None,
+    timeout_s: float | None = None,
+    status_callback: Callable[[str], None] | None = None,
+) -> AthRunResult:
+    """Generate a waveguide mesh, preferring the native HornLab mesher.
+
+    The HornLab waveguide mesher is the fast path: it is native Python (no Wine, no
+    Ath subprocess) and covers OSSE/R-OSSE-style waveguides. When it cannot handle a
+    geometry -- or is not installed -- it raises
+    :class:`HornlabWaveguideGenerationError`, and we fall back to the Ath toolchain
+    (Ath.exe, via Wine on macOS/Linux), which supports every Ath geometry but is
+    slower and needs Wine off Windows.
+    """
+
+    def _status(message: str) -> None:
+        if status_callback is not None:
+            status_callback(message)
+
+    try:
+        _status("Generating mesh (HornLab waveguide mesher)...")
+        return run_hornlab_waveguide(
+            config_text=config_text,
+            run_root=run_root,
+            case_name=case_name,
+            runner=mesher_runner,
+            timeout_s=timeout_s,
+        )
+    except AthCancelledError:
+        raise
+    except HornlabWaveguideGenerationError as mesher_exc:
+        _status("HornLab mesher unavailable for this geometry; running Ath...")
+        runner = runner or AthProcessRunner()
+        try:
+            return runner.run(
+                ath_exe=ath_exe,
+                config_text=config_text,
+                run_root=run_root,
+                case_name=case_name,
+                timeout_s=timeout_s,
+                status_callback=status_callback,
+            )
+        except AthCancelledError:
+            raise
+        except (RuntimeError, FileNotFoundError, ValueError) as ath_exc:
+            raise RuntimeError(
+                f"HornLab mesher could not generate this geometry ({mesher_exc}); Ath fallback also failed: {ath_exc}"
+            ) from ath_exc
 
 
 def _strip_ath_geo_batch_commands(geo_text: str) -> str:

--- a/src/blab/ath_config.py
+++ b/src/blab/ath_config.py
@@ -1,0 +1,111 @@
+"""Small reader for the Ath ``.cfg`` metadata Boundary Lab needs before solving."""
+
+from __future__ import annotations
+
+import re
+
+BARE_MESH_MODES = {"bare", "inner", "open"}
+ENCLOSED_MESH_MODES = {"enclosure", "enclosed"}
+FREESTANDING_MESH_MODES = {"free-standing", "freestanding", "free"}
+INFINITE_BAFFLE_MESH_MODES = {"infinite-baffle", "infinitebaffle", "ib", "baffle"}
+_ASSIGNMENT_RE = re.compile(r"^\s*(?P<key>[A-Za-z0-9_.:]+)\s*=\s*(?P<value>.*?)\s*$")
+_POLAR_BLOCK_RE = re.compile(r"^\s*ABEC\.Polars:(?P<name>[^=\s]+)\s*=\s*\{\s*$", re.IGNORECASE)
+_NUMBER_RE = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+_ENCLOSURE_DEPTH_KEYS = (
+    "enclosure.depth",
+    "enclosure.depth_mm",
+    "mesh.depth",
+    "mesh.depth_mm",
+    "encdepth",
+    "depth_mm",
+)
+
+
+def native_check_open_edges_for_ath_config(config_text: str) -> bool:
+    """Return whether a native symmetric solve should enforce open-edge checks.
+
+    Backends with native symmetry validate that a reduced mesh's open edges all
+    lie on a symmetry plane. Only bare/open waveguide modes have a real mouth rim
+    away from those planes, so they are the only Ath-family configs that opt out.
+    """
+    return _parse_mesh_mode(config_text) != "bare"
+
+
+def _parse_mesh_mode(config_text: str) -> str:
+    top_level = _parse_top_level_assignments(config_text)
+    raw_mode = _normalized_mode_value(_first_present(top_level, "mode", "mesh.mode"))
+    if raw_mode in BARE_MESH_MODES:
+        return "bare"
+    if raw_mode in ENCLOSED_MESH_MODES or _positive_depth_present(top_level):
+        return "enclosure"
+    if raw_mode in INFINITE_BAFFLE_MESH_MODES:
+        return "infinite-baffle"
+    if raw_mode in FREESTANDING_MESH_MODES:
+        return "freestanding"
+
+    sim_type = _parse_positive_int(_first_present(top_level, "abec.simtype", "simtype", "sim_type", "mesh.simtype"))
+    if sim_type == 1:
+        return "infinite-baffle"
+    return "freestanding"
+
+
+def _parse_top_level_assignments(config_text: str) -> dict[str, str]:
+    """Collect ``key = value`` pairs outside ``ABEC.Polars:<name> = { ... }`` blocks."""
+    top_level: dict[str, str] = {}
+    inside_polar_block = False
+    for raw_line in config_text.splitlines():
+        line = _strip_comment(raw_line).strip()
+        if not line:
+            continue
+        if inside_polar_block:
+            inside_polar_block = not line.startswith("}")
+            continue
+        if _POLAR_BLOCK_RE.match(line):
+            inside_polar_block = True
+            continue
+        assignment = _ASSIGNMENT_RE.match(line)
+        if assignment:
+            top_level[assignment.group("key").strip().lower()] = assignment.group("value").strip()
+    return top_level
+
+
+def _first_present(values: dict[str, str], *keys: str) -> str | None:
+    for key in keys:
+        if key in values:
+            return values[key]
+    return None
+
+
+def _normalized_mode_value(value: str | None) -> str:
+    if value is None:
+        return ""
+    return value.strip().strip('"').strip("'").lower().replace("_", "-")
+
+
+def _positive_depth_present(values: dict[str, str]) -> bool:
+    for key in _ENCLOSURE_DEPTH_KEYS:
+        depth = _parse_float(values.get(key))
+        if depth is not None and depth > 0.0:
+            return True
+    return False
+
+
+def _parse_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    match = _NUMBER_RE.search(value.strip().strip('"'))
+    if match is None:
+        return None
+    return float(match.group(0))
+
+
+def _parse_positive_int(value: str | None) -> int | None:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return None
+    rounded = int(round(parsed))
+    return rounded if rounded > 0 else None
+
+
+def _strip_comment(line: str) -> str:
+    return line.split(";", 1)[0]

--- a/src/blab/config.py
+++ b/src/blab/config.py
@@ -90,6 +90,13 @@ class SimulationConfig:
     spherical_sampling_enabled: bool = False
     spherical_sampling_points: int = 6000
     symmetry: str = "off"
+    # When a mirror-reduced (symmetric) mesh is solved, native backends that
+    # validate cut planes require every open boundary edge to lie on a symmetry
+    # plane unless this is False. An open-mouth horn's mouth rim is a real free
+    # edge off the planes, so reduced-symmetry horn solves must opt out. Only
+    # consulted when a symmetry plane is active (symmetry != "off"); ignored by
+    # backends without native symmetry.
+    native_check_open_edges: bool = True
     output_npz: str = str(SOLVER_OUTPUT_NPZ)
 
     def __post_init__(self) -> None:

--- a/src/blab/generators/ath.py
+++ b/src/blab/generators/ath.py
@@ -11,9 +11,11 @@ from blab.ath import (
     AthDriveDefinition,
     AthProcessRunner,
     AthRunResult,
+    HornlabMesherRunner,
     ath_mirror_axes_from_config_text,
     detect_ath_radiators,
     find_physical_tag_by_name,
+    generate_waveguide_mesh,
     parse_ath_drive_definitions,
 )
 from blab.generators.base import (
@@ -113,17 +115,18 @@ class AthGeneratorSession:
     def __init__(self, request: GenerationRequest, *, ath_exe: Path):
         self.request = request
         self.ath_exe = ath_exe
-        self._runner = AthProcessRunner()
+        self._ath_runner = AthProcessRunner()
+        self._mesher_runner = HornlabMesherRunner()
 
     def generate(self, *, status_callback=None, stop_requested=None) -> GeneratedGeometry:
-        if status_callback is not None:
-            status_callback("Running Ath...")
         try:
-            raw_result = self._runner.run(
+            raw_result = generate_waveguide_mesh(
                 ath_exe=self.ath_exe,
                 config_text=str(self.request.source.get("text", "")),
                 run_root=self.request.run_root,
                 case_name=self.request.case_name,
+                runner=self._ath_runner,
+                mesher_runner=self._mesher_runner,
                 status_callback=status_callback,
             )
             if stop_requested is not None and stop_requested():
@@ -136,7 +139,8 @@ class AthGeneratorSession:
             raise GenerationCancelledError(str(exc)) from exc
 
     def stop(self) -> None:
-        self._runner.stop()
+        self._mesher_runner.stop()
+        self._ath_runner.stop()
 
 
 class AthGeneratorBackend(GeneratorBackend):

--- a/src/blab/postprocess.py
+++ b/src/blab/postprocess.py
@@ -19,6 +19,8 @@ from scipy.interpolate import RegularGridInterpolator
 
 from blab.defaults import FORMATTED_OUTPUT_NPZ, SOLVER_OUTPUT_NPZ
 
+MIN_USEFUL_DB_SPAN = 6.0
+
 
 @dataclass
 class PrepConfig:
@@ -276,13 +278,16 @@ def prepare_visualization_data_from_arrays(
     horizontal = _fractional_octave_smooth(horizontal, freq_hz, cfg.octave_smoothing)
     vertical = _fractional_octave_smooth(vertical, freq_hz, cfg.octave_smoothing)
     clip_min_db, clip_max_db = _resolve_db_span(horizontal, vertical, cfg)
-    horizontal = np.clip(horizontal, clip_min_db, clip_max_db)
-    vertical = np.clip(vertical, clip_min_db, clip_max_db)
+    polar_clip_min_db, polar_clip_max_db = _resolve_polar_db_span(horizontal, vertical, cfg)
+    horizontal_clipped = np.clip(horizontal, polar_clip_min_db, polar_clip_max_db)
+    vertical_clipped = np.clip(vertical, polar_clip_min_db, polar_clip_max_db)
+    horizontal_isobar = np.clip(horizontal, clip_min_db, clip_max_db)
+    vertical_isobar = np.clip(vertical, clip_min_db, clip_max_db)
 
     isobar_angles, isobar_freqs, horizontal_interp = _interpolate_isobar_heatmap(
         base_angles_deg,
         freq_hz,
-        horizontal,
+        horizontal_isobar,
         cfg.angle_samples,
         cfg.freq_samples,
         clip_min_db,
@@ -290,7 +295,7 @@ def prepare_visualization_data_from_arrays(
     _, _, vertical_interp = _interpolate_isobar_heatmap(
         base_angles_deg,
         freq_hz,
-        vertical,
+        vertical_isobar,
         cfg.angle_samples,
         cfg.freq_samples,
         clip_min_db,
@@ -306,8 +311,8 @@ def prepare_visualization_data_from_arrays(
         "polar_angle_deg": base_angles_deg,
         "horizontal_spl_db": raw_horizontal.astype(np.float32, copy=False),
         "vertical_spl_db": raw_vertical.astype(np.float32, copy=False),
-        "horizontal_spl_norm_db": horizontal.T.astype(np.float32, copy=False),
-        "vertical_spl_norm_db": vertical.T.astype(np.float32, copy=False),
+        "horizontal_spl_norm_db": horizontal_clipped.T.astype(np.float32, copy=False),
+        "vertical_spl_norm_db": vertical_clipped.T.astype(np.float32, copy=False),
         "isobar_angle_deg": isobar_angles.astype(np.float32, copy=False),
         "isobar_freq_hz": isobar_freqs.astype(np.float32, copy=False),
         "horizontal_isobar_db": horizontal_interp,
@@ -327,18 +332,67 @@ def prepare_visualization_data_from_arrays(
 
 
 def _resolve_db_span(horizontal: np.ndarray, vertical: np.ndarray, cfg: PrepConfig) -> tuple[float, float]:
+    combined = np.concatenate([horizontal.ravel(), vertical.ravel()])
+    finite = combined[np.isfinite(combined)]
+
     if not cfg.auto_db_span:
+        min_db = float(cfg.min_db)
+        max_db = float(cfg.max_db)
+        if max_db <= min_db:
+            max_db = min_db + 1.0
+        if finite.size == 0:
+            return min_db, max_db
+
+        finite_min = float(np.min(finite))
+        finite_max = float(np.max(finite))
+        if finite_max < min_db or finite_min > max_db:
+            return _auto_db_span_from_finite(finite, min_db, max_db)
+        clipped_min = max(finite_min, min_db)
+        clipped_max = min(finite_max, max_db)
+        if clipped_max > clipped_min and clipped_max - clipped_min < MIN_USEFUL_DB_SPAN:
+            return _auto_db_span_from_finite(finite, min_db, max_db)
+        return min_db, max_db
+
+    if finite.size == 0:
         return float(cfg.min_db), float(cfg.max_db)
+
+    return _auto_db_span_from_finite(finite, float(cfg.min_db), float(cfg.max_db))
+
+
+def _resolve_polar_db_span(horizontal: np.ndarray, vertical: np.ndarray, cfg: PrepConfig) -> tuple[float, float]:
+    if cfg.auto_db_span:
+        return _resolve_db_span(horizontal, vertical, cfg)
+
+    min_db = float(cfg.min_db)
+    max_db = float(cfg.max_db)
+    if max_db <= min_db:
+        max_db = min_db + 1.0
 
     combined = np.concatenate([horizontal.ravel(), vertical.ravel()])
     finite = combined[np.isfinite(combined)]
     if finite.size == 0:
-        return float(cfg.min_db), float(cfg.max_db)
+        return min_db, max_db
 
+    finite_min = float(np.min(finite))
+    finite_max = float(np.max(finite))
+    if finite_max < min_db or finite_min > max_db:
+        return _auto_db_span_from_finite(finite, min_db, max_db)
+    return min_db, max_db
+
+
+def _auto_db_span_from_finite(
+    finite: np.ndarray, fallback_min_db: float, fallback_max_db: float
+) -> tuple[float, float]:
     min_db = float(np.floor(np.min(finite)))
     max_db = float(np.ceil(np.max(finite)))
     if np.isclose(min_db, max_db):
         max_db = min_db + 1.0
+    if max_db <= min_db:
+        return fallback_min_db, fallback_max_db if fallback_max_db > fallback_min_db else fallback_min_db + 1.0
+    if max_db - min_db < MIN_USEFUL_DB_SPAN:
+        if float(np.max(finite)) <= fallback_max_db <= max_db + MIN_USEFUL_DB_SPAN:
+            max_db = fallback_max_db
+        min_db = max_db - MIN_USEFUL_DB_SPAN
     return min_db, max_db
 
 

--- a/src/blab/solvers/registry.py
+++ b/src/blab/solvers/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Callable
 
 from blab.solvers.base import SolverBackend, SolverCapabilities
@@ -16,6 +17,18 @@ class SolverBackendInfo:
     factory: Callable[..., SolverBackend] | None = None
     available: bool = True
     description: str = ""
+
+
+@lru_cache(maxsize=1)
+def _hornlab_metal_probe() -> tuple[bool, SolverCapabilities]:
+    """Return the installed Metal adapter's availability and capabilities."""
+    try:
+        from hornlab_metal_bem.boundary_lab import create_backend as create_hornlab_backend
+
+        backend = create_hornlab_backend()
+        return bool(backend.supports()), backend.capabilities
+    except Exception:
+        return False, SolverCapabilities()
 
 
 _BACKENDS: dict[str, SolverBackendInfo] = {
@@ -79,6 +92,14 @@ _BACKENDS: dict[str, SolverBackendInfo] = {
         ),
         factory=lambda **_kwargs: _create_bempp_local_backend(),
         description="Run the bundled bempp-cl OpenCL CPU solver in the GUI process.",
+    ),
+    "hornlab_metal": SolverBackendInfo(
+        backend_id="hornlab_metal",
+        label="HornLab Metal BEM",
+        capabilities=_hornlab_metal_probe()[1],
+        factory=lambda **kwargs: _create_hornlab_metal_backend(**kwargs),
+        available=_hornlab_metal_probe()[0],
+        description="Run the native HornLab Apple Metal solver on Apple Silicon macOS.",
     ),
 }
 
@@ -146,6 +167,10 @@ def normalize_backend_id(backend_id: str) -> str:
         "rocm": "beat_rocm",
         "amd": "beat_rocm",
         "amdgpu": "beat_rocm",
+        "hornlab": "hornlab_metal",
+        "hornlab_metal": "hornlab_metal",
+        "metal": "hornlab_metal",
+        "apple_metal": "hornlab_metal",
     }
     return aliases.get(text, text or "local")
 
@@ -158,6 +183,24 @@ def _create_bempp_local_backend() -> SolverBackend:
     from blab.solvers.bempp_local import BemppLocalBackend
 
     return BemppLocalBackend()
+
+
+def _create_hornlab_metal_backend(**_kwargs: Any) -> SolverBackend:
+    from hornlab_metal_bem.boundary_lab import create_backend as create_hornlab_backend
+
+    return create_hornlab_backend()
+
+
+def backend_provenance(backend_id: str) -> dict[str, str]:
+    """Return backend build details worth recording with a run's results."""
+    if normalize_backend_id(backend_id) != "hornlab_metal":
+        return {}
+    try:
+        from importlib import metadata
+
+        return {"hornlab_metal_bem_version": metadata.version("hornlab-metal-bem")}
+    except Exception:
+        return {}
 
 
 def _create_bempp_server_backend(

--- a/src/blab/ui/dialogs.py
+++ b/src/blab/ui/dialogs.py
@@ -718,6 +718,8 @@ class MeshConfigDialog(QDialog):
         scale_spin.setDecimals(6)
         scale_spin.setSingleStep(0.001)
         scale_spin.setValue(float(mesh.scale_factor))
+        if mesh.locked:
+            scale_spin.setEnabled(False)
         self.table.setCellWidget(row, 3, scale_spin)
         self.scale_widgets.append(scale_spin)
 

--- a/src/blab/ui/drag_drop.py
+++ b/src/blab/ui/drag_drop.py
@@ -7,6 +7,16 @@ from pathlib import Path
 
 def local_drop_paths(event) -> list[Path]:
     mime_data = event.mimeData()
-    if not mime_data.hasUrls():
-        return []
-    return [Path(url.toLocalFile()) for url in mime_data.urls() if url.isLocalFile()]
+    paths = [Path(url.toLocalFile()) for url in mime_data.urls() if url.isLocalFile()] if mime_data.hasUrls() else []
+    if paths or not mime_data.hasText():
+        return paths
+
+    text_paths = []
+    for line in mime_data.text().splitlines():
+        text = line.strip().strip("'\"")
+        if not text:
+            continue
+        path = Path(text).expanduser()
+        if path.exists():
+            text_paths.append(path)
+    return text_paths

--- a/src/blab/ui/main_window/solve_workflow.py
+++ b/src/blab/ui/main_window/solve_workflow.py
@@ -16,6 +16,8 @@ from collections.abc import Callable
 import numpy as np
 from PySide6.QtCore import QObject, Signal, Slot
 
+from blab.ath_config import native_check_open_edges_for_ath_config
+from blab.generators.ath import ATH_PROVIDER_ID, ath_source_text
 from blab.live import (
     FrequencyResult,
     LiveSolveDataset,
@@ -32,6 +34,7 @@ from blab.solve_results import (
     legacy_result_domains,
     legacy_result_to_system_result,
 )
+from blab.solvers.registry import backend_provenance
 from blab.speaker_package import (
     SpeakerPackageConfig,
     export_speaker_package,
@@ -151,6 +154,20 @@ class SolveWorkflowController(QObject):
             symmetry=self._project().symmetry,
         )
 
+    def _native_check_open_edges(self) -> bool:
+        """Keep strict Metal validation except for generated bare/open horns."""
+        project = self._project()
+        if project.symmetry == "off":
+            return True
+        generated_ath_documents = (
+            document
+            for document in project.generator_documents
+            if document.provider_id == ATH_PROVIDER_ID and document.mesh_enabled and document.artifact is not None
+        )
+        return all(
+            native_check_open_edges_for_ath_config(ath_source_text(document)) for document in generated_ath_documents
+        )
+
     @Slot()
     def start_solve(self) -> None:
         if self._geometry_controller.active or self._solve_controller.active:
@@ -200,6 +217,8 @@ class SolveWorkflowController(QObject):
         except SymmetryValidationError as exc:
             self._view.warn("Symmetry validation failed", str(exc))
             return
+
+        prepared_simulation.config.native_check_open_edges = self._native_check_open_edges()
 
         self._begin_run("Initializing Solver...")
         self._solve_controller.start(
@@ -317,6 +336,8 @@ class SolveWorkflowController(QObject):
             self._view.show_stitch_or_generic_error("Exterior system preparation failed", exc)
             return
 
+        prepared_simulation.config.native_check_open_edges = self._native_check_open_edges()
+
         self._begin_run("Initializing exterior solver...")
         self._solve_controller.start(
             self._solve_request(prepared_simulation.config, prepared_simulation.ordered_frequencies)
@@ -363,7 +384,10 @@ class SolveWorkflowController(QObject):
             provenance=SolveProvenance(
                 backend_id=prepared.backend_id,
                 solve_kind=prepared.solve_kind.value,
-                solver_options=dict(prepared.request.solver_options),
+                solver_options={
+                    **prepared.request.solver_options,
+                    **backend_provenance(prepared.backend_id),
+                },
             ),
             domains=prepared.result_domains,
             compiled_system=prepared.request.compiled_system,

--- a/src/blab/ui/plots.py
+++ b/src/blab/ui/plots.py
@@ -798,10 +798,17 @@ class IsobarCanvas(InteractivePlotCanvas):
             )
         )
 
-    def _color_mapping(self, clip_min_db: float, clip_max_db: float, contour_step_db: float):
+    def _color_mapping(
+        self,
+        clip_min_db: float,
+        clip_max_db: float,
+        contour_step_db: float,
+        *,
+        discrete: bool = True,
+    ):
         cmap = self._isobar_colormap()
         boundaries = self._color_boundaries(clip_min_db, clip_max_db, contour_step_db)
-        if boundaries.size >= 2:
+        if discrete and boundaries.size >= 2:
             return cmap, BoundaryNorm(boundaries, cmap.N)
         return cmap, Normalize(vmin=clip_min_db, vmax=clip_max_db)
 
@@ -846,16 +853,6 @@ class IsobarCanvas(InteractivePlotCanvas):
         self._colorbar.ax.tick_params(labelsize=PLOT_TICK_SIZE)
         self._colorbar_state = state
 
-    def _image_from_values(
-        self,
-        clipped: np.ndarray,
-        clip_min_db: float,
-        clip_max_db: float,
-        contour_step_db: float,
-    ) -> np.ndarray:
-        cmap, norm = self._color_mapping(clip_min_db, clip_max_db, contour_step_db)
-        return np.asarray(cmap(norm(clipped)), dtype=np.float32)
-
     def update_plot(
         self,
         freqs_hz: np.ndarray,
@@ -870,9 +867,12 @@ class IsobarCanvas(InteractivePlotCanvas):
         freqs_hz = np.asarray(freqs_hz, dtype=np.float32)
         angles_deg = np.asarray(angles_deg, dtype=np.float32)
         clipped = np.clip(np.asarray(values_db, dtype=np.float32), clip_min_db, clip_max_db)
+        finite = clipped[np.isfinite(clipped)]
+        data_span_db = 0.0 if finite.size == 0 else float(np.max(finite) - np.min(finite))
         clip = (float(clip_min_db), float(clip_max_db))
         shading = str(shading or LIVE_ISOBAR_SHADING)
         contour_step_db = max(0.0, float(contour_step_db))
+        discrete_colors = contour_step_db <= 0.0 or data_span_db >= 2.0 * contour_step_db
         render_mode = "image" if shading == FINAL_ISOBAR_SHADING else "mesh"
         state = (
             freqs_hz.copy(),
@@ -889,7 +889,12 @@ class IsobarCanvas(InteractivePlotCanvas):
 
         if freqs_hz.size >= 2 and angles_deg.size >= 2:
             self._remove_artist("_line_artist")
-            cmap, norm = self._color_mapping(clip_min_db, clip_max_db, contour_step_db)
+            cmap, norm = self._color_mapping(
+                clip_min_db,
+                clip_max_db,
+                contour_step_db,
+                discrete=discrete_colors,
+            )
             self._update_colorbar(clip_min_db, clip_max_db, contour_step_db, cmap, norm)
             if render_mode == "image":
                 self._x_axis_mode = "log_image"

--- a/src/blab/ui/project_io.py
+++ b/src/blab/ui/project_io.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import copy
 import json
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from blab.observation_planes import observation_planes_from_payload
@@ -316,7 +316,10 @@ def _resolve_path_fields(payload: dict[str, Any], base_dir: Path, fields: tuple[
         if not text:
             continue
         path = Path(text)
-        if path.is_absolute():
+        # A Windows absolute path ("C:/meshes/horn.msh") is relative to POSIX, so
+        # loading a Windows project on macOS/Linux would rewrite it under the
+        # project directory. Treat a drive letter as absolute on every platform.
+        if path.is_absolute() or PureWindowsPath(text).drive:
             continue
         payload[field] = str((base_dir / path).resolve())
 

--- a/tests/test_ath_config.py
+++ b/tests/test_ath_config.py
@@ -1,0 +1,34 @@
+import pytest
+
+from blab.ath_config import native_check_open_edges_for_ath_config
+
+
+@pytest.mark.parametrize(
+    ("config_text", "expected"),
+    (
+        ("Mesh.Mode = bare\n", False),
+        ("mode = open\n", False),
+        ("mode = freestanding\n", True),
+        ("ABEC.SimType = 1\n", True),
+        ("Enclosure.Depth = 120\n", True),
+        ("", True),
+    ),
+)
+def test_native_open_edge_check_only_opts_out_for_bare_modes(config_text: str, expected: bool) -> None:
+    assert native_check_open_edges_for_ath_config(config_text) is expected
+
+
+def test_mesh_mode_inside_polar_block_is_ignored() -> None:
+    config_text = "\n".join(
+        (
+            "ABEC.Polars:SPL_H = {",
+            "  Mode = bare",
+            "}",
+            "",
+        )
+    )
+    assert native_check_open_edges_for_ath_config(config_text) is True
+
+
+def test_comments_do_not_hide_the_mesh_mode() -> None:
+    assert native_check_open_edges_for_ath_config("Mesh.Mode = bare ; open-mouth horn\n") is False

--- a/tests/test_ath_live.py
+++ b/tests/test_ath_live.py
@@ -79,6 +79,8 @@ class _FakeAthProcess:
 
 
 def test_ath_process_runner_captures_blaba_output_and_launches_gmsh_worker(tmp_path: Path, monkeypatch) -> None:
+    # This test drives Ath directly, so pin a platform that runs it without Wine.
+    monkeypatch.setattr("blab.ath.sys.platform", "win32")
     ath_dir = tmp_path / "ath"
     ath_dir.mkdir()
     ath_exe = ath_dir / "ath.exe"

--- a/tests/test_generator_backends.py
+++ b/tests/test_generator_backends.py
@@ -11,7 +11,7 @@ from blab.generators.ath import (
     ath_source,
     generated_geometry_to_ath_result,
 )
-from blab.generators.base import GeneratedGeometryReference, GeneratorDocument
+from blab.generators.base import GeneratedGeometryReference, GenerationRequest, GeneratorDocument
 from blab.generators.registry import available_generator_infos, create_generator, generator_info
 
 
@@ -86,3 +86,37 @@ def test_ath_backend_restores_generic_geometry_from_document_artifact(tmp_path: 
     assert restored.radiators[0].drive_group == "ath:0"
     assert restored.radiators[0].drive_group_name == "horn_driver"
     assert restored.radiators[0].velocity_offset_db == -6.0206
+
+
+def test_ath_generator_session_prefers_the_hornlab_mesher(tmp_path: Path, monkeypatch) -> None:
+    """The session must route through generate_waveguide_mesh, not straight to Ath."""
+    mesh_path = tmp_path / "waveguide.msh"
+    raw_result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=mesh_path,
+        config_path=tmp_path / "waveguide.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+    captured: dict = {}
+
+    def fake_generate_waveguide_mesh(**kwargs):
+        captured.update(kwargs)
+        return raw_result
+
+    monkeypatch.setattr("blab.generators.ath.generate_waveguide_mesh", fake_generate_waveguide_mesh)
+    request = GenerationRequest(
+        provider_id=ATH_PROVIDER_ID,
+        document_id="design1",
+        mesh_name="waveguide",
+        source=ath_source("Length = 100"),
+        run_root=tmp_path,
+        case_name="waveguide",
+    )
+
+    generated = AthGeneratorBackend(ath_exe="ath/ath202608.exe").create_session(request).generate()
+
+    assert generated.mesh_path == mesh_path
+    assert captured["config_text"] == "Length = 100"
+    assert type(captured["mesher_runner"]).__name__ == "HornlabMesherRunner"
+    assert type(captured["runner"]).__name__ == "AthProcessRunner"

--- a/tests/test_hornlab_mesher.py
+++ b/tests/test_hornlab_mesher.py
@@ -1,0 +1,191 @@
+"""The HornLab waveguide mesher fast path and its fallback to Ath."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import meshio
+import numpy as np
+import pytest
+
+from blab.ath import (
+    AthRunResult,
+    HornlabWaveguideGenerationError,
+    generate_waveguide_mesh,
+    run_hornlab_waveguide,
+)
+
+SUPPORTED_CONFIG = "Throat.Diameter = 25.4\nMesh.Quadrants = 1234\n"
+
+
+def _quadrant_mesh(path: Path) -> None:
+    """A two-triangle patch tagged as the Ath driven diaphragm surface."""
+    meshio.write(
+        path,
+        meshio.Mesh(
+            points=np.array(
+                [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 10.0, 0.0], [0.0, 10.0, 0.0]],
+                dtype=np.float64,
+            ),
+            cells=[("triangle", np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int64))],
+            cell_data={"gmsh:physical": [np.array([2, 2], dtype=np.int32)]},
+            field_data={"SD1D1001": np.array([2, 2], dtype=np.int32)},
+        ),
+        file_format="gmsh22",
+        binary=False,
+    )
+
+
+class FakeMesherRunner:
+    """Stands in for the hornlab_mesher subprocess."""
+
+    def __init__(self, **result_overrides) -> None:
+        self.result = {
+            "mesher_version": "0.1.0",
+            "formula": "osse",
+            "mode": "bare",
+            "units": "mm",
+            "quadrants": "1234",
+            "n_vertices": 4,
+            "n_triangles": 2,
+            **result_overrides,
+        }
+        self.calls: list[tuple[Path, Path]] = []
+
+    def run(self, config_path: Path, msh_path: Path, *, timeout_s: float | None = None) -> dict:
+        self.calls.append((config_path, msh_path))
+        _quadrant_mesh(msh_path)
+        return dict(self.result)
+
+    def stop(self) -> None:  # pragma: no cover - the fast path never cancels here
+        pass
+
+
+def test_mesher_output_becomes_a_normal_ath_run_result(tmp_path: Path) -> None:
+    result = run_hornlab_waveguide(
+        config_text=SUPPORTED_CONFIG,
+        run_root=tmp_path,
+        case_name="waveguide",
+        runner=FakeMesherRunner(),
+    )
+
+    assert isinstance(result, AthRunResult)
+    assert result.driven_tag == 2
+    assert result.cleaned_msh_path.exists()
+    assert result.config_path.read_text(encoding="utf-8") == SUPPORTED_CONFIG
+    # The raw mesher mesh is a working file and must not survive the run.
+    assert not list(result.output_dir.glob(".*_hornlab_raw.msh"))
+
+
+def test_each_mesher_run_records_its_package_provenance(tmp_path: Path) -> None:
+    result = run_hornlab_waveguide(
+        config_text=SUPPORTED_CONFIG,
+        run_root=tmp_path,
+        case_name="waveguide",
+        runner=FakeMesherRunner(),
+    )
+
+    provenance = json.loads((result.output_dir / "hornlab_mesher.json").read_text(encoding="utf-8"))
+    assert provenance["mesher_version"] == "0.1.0"
+    assert provenance["formula"] == "osse"
+    assert provenance["units"] == "mm"
+
+
+def test_a_quadrant_disagreement_never_gets_mirrored(tmp_path: Path) -> None:
+    """Mirroring a mesh against the wrong axes would silently change the model."""
+    with pytest.raises(HornlabWaveguideGenerationError, match="quadrants"):
+        run_hornlab_waveguide(
+            config_text="Mesh.Quadrants = 1\n",
+            run_root=tmp_path,
+            case_name="waveguide",
+            runner=FakeMesherRunner(quadrants="1234"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("config_text", "reason"),
+    (
+        ("Throat.Ext.Length = 20\n", "Throat.Ext.Length"),
+        ("Source.Contours = {\n", "multi-source"),
+        ("LFSource.Diameter = 200\n", "multi-source"),
+        ("ABEC.SimType = 2\nMesh.SubdomainSlices = 1\n", "two-subdomain"),
+    ),
+)
+def test_geometry_the_mesher_cannot_build_is_refused_before_meshing(
+    tmp_path: Path, config_text: str, reason: str
+) -> None:
+    runner = FakeMesherRunner()
+    with pytest.raises(HornlabWaveguideGenerationError, match=reason):
+        run_hornlab_waveguide(config_text=config_text, run_root=tmp_path, runner=runner)
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize(
+    "config_text",
+    (
+        "Throat.Ext.Length = 0\n",
+        "Throat.Ext.Angle = 20\n",
+        "Source.VelocityProfile = profile.txt\n",
+        "ABEC.SimType = 1\nMesh.SubdomainSlices = 1\n",
+    ),
+)
+def test_supported_geometry_is_not_diverted_to_ath(tmp_path: Path, config_text: str) -> None:
+    runner = FakeMesherRunner()
+    run_hornlab_waveguide(config_text=config_text, run_root=tmp_path, runner=runner)
+    assert len(runner.calls) == 1
+
+
+def test_unsupported_geometry_falls_back_to_the_ath_toolchain(tmp_path: Path) -> None:
+    ath_result = AthRunResult(
+        output_dir=tmp_path,
+        msh_path=tmp_path / "waveguide.msh",
+        config_path=tmp_path / "waveguide.cfg",
+        driven_tag=2,
+        radiators=(),
+    )
+    statuses: list[str] = []
+
+    class FakeAthRunner:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run(self, **_kwargs) -> AthRunResult:
+            self.calls += 1
+            return ath_result
+
+    ath_runner = FakeAthRunner()
+    mesher_runner = FakeMesherRunner()
+
+    result = generate_waveguide_mesh(
+        ath_exe=tmp_path / "ath202608.exe",
+        config_text="Throat.Ext.Length = 20\n",
+        run_root=tmp_path,
+        runner=ath_runner,
+        mesher_runner=mesher_runner,
+        status_callback=statuses.append,
+    )
+
+    assert result is ath_result
+    assert ath_runner.calls == 1
+    assert mesher_runner.calls == []
+    assert any("running Ath" in status for status in statuses)
+
+
+def test_a_failing_ath_fallback_reports_both_failures(tmp_path: Path) -> None:
+    class FailingAthRunner:
+        def run(self, **_kwargs) -> AthRunResult:
+            raise RuntimeError("Ath failed with exit code 1")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        generate_waveguide_mesh(
+            ath_exe=tmp_path / "ath202608.exe",
+            config_text="Throat.Ext.Length = 20\n",
+            run_root=tmp_path,
+            runner=FailingAthRunner(),
+            mesher_runner=FakeMesherRunner(),
+        )
+
+    message = str(excinfo.value)
+    assert "Throat.Ext.Length" in message
+    assert "exit code 1" in message

--- a/tests/test_mesh_config_dialog.py
+++ b/tests/test_mesh_config_dialog.py
@@ -1,0 +1,19 @@
+from PySide6.QtWidgets import QApplication
+
+from blab.ui.dialogs import MeshConfigDialog, MeshDialogEntry
+
+_APP = QApplication.instance() or QApplication([])
+
+
+def test_locked_generated_mesh_scale_is_not_editable() -> None:
+    dialog = MeshConfigDialog(
+        (
+            MeshDialogEntry(name="ath", source_file="ath.msh", scale_factor=0.001, locked=True),
+            MeshDialogEntry(name="cabinet", source_file="cabinet.msh", scale_factor=0.001),
+        )
+    )
+    try:
+        assert not dialog.scale_widgets[0].isEnabled()
+        assert dialog.scale_widgets[1].isEnabled()
+    finally:
+        dialog.close()

--- a/tests/test_package_dependencies.py
+++ b/tests/test_package_dependencies.py
@@ -1,0 +1,22 @@
+import tomllib
+from pathlib import Path
+
+
+def test_hornlab_integrations_are_declared_as_public_dependencies() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+
+    assert pyproject["tool"]["hatch"]["metadata"]["allow-direct-references"] is True
+
+    mesher = next(dep for dep in dependencies if dep.startswith("hornlab-waveguide-mesher @ "))
+    metal = next(dep for dep in dependencies if dep.startswith("hornlab-metal-bem @ "))
+
+    assert "git+https://github.com/m3gnus/hornlab-waveguide-mesher.git@" in mesher
+    assert "git+https://github.com/m3gnus/hornlab-metal-bem.git@" in metal
+    # Windows installs must not pull either package.
+    assert "platform_system != 'Windows'" in mesher
+    assert "platform_system == 'Darwin'" in metal
+    assert "platform_machine == 'arm64'" in metal
+    # Never re-introduce machine-local editable paths.
+    assert "/Users/" not in "\n".join(dependencies)

--- a/tests/test_postprocess_plotting.py
+++ b/tests/test_postprocess_plotting.py
@@ -130,6 +130,75 @@ def test_prepare_visualization_data_can_skip_normalization_and_auto_span() -> No
     assert np.allclose(dataset["horizontal_spl_norm_db"], horizontal)
 
 
+def test_prepare_visualization_data_expands_fixed_span_when_everything_would_clip() -> None:
+    freqs = np.array([200.0, 1000.0], dtype=np.float32)
+    angles = np.array([-90.0, 0.0, 90.0], dtype=np.float32)
+    horizontal = np.array([[21.2, 28.4, 22.5], [24.0, 30.1, 25.0]], dtype=np.float32)
+    vertical = horizontal - 2.0
+
+    dataset = prepare_visualization_data_from_arrays(
+        freq_hz=freqs,
+        polar_angle_deg=angles,
+        horizontal_spl_norm_db=horizontal,
+        vertical_spl_norm_db=vertical,
+        impedance_freq_hz=freqs,
+        impedance_radiator_names=np.array(["throat"]),
+        impedance_real=np.ones((1, 2), dtype=np.float32),
+        impedance_imag=np.zeros((1, 2), dtype=np.float32),
+        cfg=PrepConfig(
+            angle_samples=None,
+            freq_samples=None,
+            octave_smoothing=None,
+            normalize_polar=False,
+            auto_db_span=False,
+            min_db=-30.0,
+            max_db=0.0,
+        ),
+    )
+
+    assert dataset["clip_min_db"] == 19.0
+    assert dataset["clip_max_db"] == 31.0
+    assert np.nanmin(dataset["horizontal_isobar_db"]) < np.nanmax(dataset["horizontal_isobar_db"])
+
+
+def test_prepare_visualization_data_expands_narrow_fixed_span_for_visible_isobar() -> None:
+    freqs = np.array([500.0, 1000.0, 2000.0], dtype=np.float32)
+    angles = np.array([-90.0, -45.0, 0.0, 45.0, 90.0], dtype=np.float32)
+    horizontal = np.array(
+        [
+            [-1.4, -0.7, 0.2, -0.6, -1.2],
+            [-2.2, -1.0, 0.4, -0.8, -1.8],
+            [-2.8, -1.4, 0.1, -1.1, -2.3],
+        ],
+        dtype=np.float32,
+    )
+    vertical = horizontal - 0.4
+
+    dataset = prepare_visualization_data_from_arrays(
+        freq_hz=freqs,
+        polar_angle_deg=angles,
+        horizontal_spl_norm_db=horizontal,
+        vertical_spl_norm_db=vertical,
+        impedance_freq_hz=freqs,
+        impedance_radiator_names=np.array(["throat"]),
+        impedance_real=np.ones((1, 3), dtype=np.float32),
+        impedance_imag=np.zeros((1, 3), dtype=np.float32),
+        cfg=PrepConfig(
+            angle_samples=None,
+            freq_samples=None,
+            octave_smoothing=None,
+            normalize_polar=False,
+            auto_db_span=False,
+            min_db=-30.0,
+            max_db=0.0,
+        ),
+    )
+
+    assert dataset["clip_min_db"] == -5.0
+    assert dataset["clip_max_db"] == 1.0
+    assert np.nanmin(dataset["horizontal_isobar_db"]) < np.nanmax(dataset["horizontal_isobar_db"])
+
+
 def test_prepare_visualization_data_preserves_raw_spl_for_on_axis_response() -> None:
     freqs = np.array([200.0, 1000.0], dtype=np.float32)
     angles = np.array([-90.0, 0.0, 90.0], dtype=np.float32)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -59,6 +59,7 @@ def test_simulation_config_round_trips_through_wire_dict() -> None:
         spherical_sampling_enabled=True,
         spherical_sampling_points=32,
         symmetry="xy",
+        native_check_open_edges=False,
     )
 
     restored = simulation_config_from_dict(simulation_config_to_dict(config))
@@ -75,6 +76,14 @@ def test_simulation_config_round_trips_through_wire_dict() -> None:
     assert restored.channels[0].lpf.frequency_hz == 20000.0
     assert restored.spherical_sampling_enabled is True
     assert restored.symmetry == "xy"
+    assert restored.native_check_open_edges is False
+
+
+def test_simulation_config_defaults_open_edge_check_on_for_old_payloads() -> None:
+    # A payload from before the field existed must restore to the strict default.
+    payload = simulation_config_to_dict(SimulationConfig(mesh_file="m.msh"))
+    del payload["native_check_open_edges"]
+    assert simulation_config_from_dict(payload).native_check_open_edges is True
 
 
 def test_frequency_result_round_trips_through_wire_dict() -> None:

--- a/tests/test_solve_workflow_controller.py
+++ b/tests/test_solve_workflow_controller.py
@@ -8,8 +8,11 @@ describes the behaviour that must survive.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
+from blab.generators.base import GeneratedGeometryReference  # noqa: E402
 from blab.ui.application_state import OperationPhase, SolveCompletion  # noqa: E402
 from blab.ui.main_window.solve_session import SolveSession  # noqa: E402
 from blab.ui.main_window.solve_workflow import SolveWorkflowController  # noqa: E402
@@ -132,6 +135,33 @@ def controller(qapp):
     built.view, built.plots, built.inputs = view, plots, inputs
     built.session, built.geometry, built.solve = session, geometry, solve
     return built
+
+
+def _project_with_generated_horn(config_text: str, symmetry: str):
+    project = new_project_document(config_text)
+    project.symmetry = symmetry
+    project.generator_documents = (
+        replace(
+            project.generator_documents[0],
+            artifact=GeneratedGeometryReference(output_dir="run", mesh_path="horn.msh"),
+        ),
+    )
+    return project
+
+
+@pytest.mark.parametrize(
+    ("config_text", "symmetry", "expected"),
+    (
+        ("Mesh.Mode = bare\n", "xy", False),
+        ("Mesh.Mode = bare\n", "off", True),
+        ("ABEC.SimType = 2\n", "xy", True),
+    ),
+)
+def test_generated_bare_horns_relax_the_native_open_edge_check(config_text, symmetry, expected) -> None:
+    project = _project_with_generated_horn(config_text, symmetry)
+    workflow = type("Workflow", (), {"_project": lambda _self: project})()
+
+    assert SolveWorkflowController._native_check_open_edges(workflow) is expected
 
 
 def test_the_controller_needs_no_main_window(controller) -> None:

--- a/tests/test_solver_backends.py
+++ b/tests/test_solver_backends.py
@@ -59,6 +59,8 @@ def test_solver_backend_registry_keeps_legacy_ids_available() -> None:
     assert normalize_backend_id("beat_rocm") == "beat_rocm"
     assert normalize_backend_id("rocm") == "beat_rocm"
     assert normalize_backend_id("amdgpu") == "beat_rocm"
+    assert normalize_backend_id("metal") == "hornlab_metal"
+    assert normalize_backend_id("hornlab") == "hornlab_metal"
     assert JuliaLocalBackend is BeatEngineBackend
     assert BeatEngineRocmBackend.beat_engine_backend == "rocm"
     assert BemppServerBackend is HttpServerBackend
@@ -69,6 +71,7 @@ def test_solver_backend_registry_keeps_legacy_ids_available() -> None:
     assert backend_info("beat_cuda").capabilities.supports_symmetry is True
     assert backend_info("beat_cpu").capabilities.supports_symmetry is True
     assert backend_info("beat_rocm").capabilities.supports_symmetry is True
+    assert backend_info("hornlab_metal").label == "HornLab Metal BEM"
     assert "beat_cuda" in {info.backend_id for info in available_backend_infos()}
     assert "beat_cpu" in {info.backend_id for info in available_backend_infos()}
     assert "beat_rocm" in {info.backend_id for info in available_backend_infos()}

--- a/tests/test_ui_plot_classes.py
+++ b/tests/test_ui_plot_classes.py
@@ -321,6 +321,9 @@ def test_isobar_canvas_reuses_heatmap_artist_between_grid_changes() -> None:
     assert "LinearSegmentedColormap.from_list" in isobar_block
     assert "Normalize(vmin=clip_min_db, vmax=clip_max_db)" in isobar_block
     assert "BoundaryNorm(boundaries, cmap.N)" in isobar_block
+    assert "data_span_db = 0.0 if finite.size == 0 else float(np.max(finite) - np.min(finite))" in isobar_block
+    assert "discrete_colors = contour_step_db <= 0.0 or data_span_db >= 2.0 * contour_step_db" in isobar_block
+    assert "discrete=discrete_colors" in isobar_block
     assert "ScalarMappable(norm=norm, cmap=cmap)" in isobar_block
     assert "self.figure.add_axes" in isobar_block
     assert "cax=self._colorbar_axes" in isobar_block


### PR DESCRIPTION
Rebuilt on current `main` (2d7dad2). The earlier branch predated the Ath-blab-mode
rewrite, so this is a fresh port rather than a rebase: the mesher now feeds
`build_ath_mesh_artifacts` directly instead of faking an ABEC output directory.

## What this changes

**Waveguide generation without Wine.** Ath geometry generation tries the HornLab
waveguide mesher first and falls back to the Ath toolchain. Both paths return the
same `AthRunResult` — the mesher's raw mesh goes through Boundary Lab's own
cleaning and mirroring stage, so cleaned/reduced/expanded artifacts are produced
identically. Configs the mesher cannot build (throat extension tubes,
multi-source models, free-standing subdomain interfaces) are routed to Ath up
front. If the mesher reports different quadrant coverage than `Mesh.Quadrants`
implies, the run goes to Ath rather than being mirrored against the wrong axes.

**HornLab Metal BEM backend.** Registered as `hornlab_metal`, listed only when
`hornlab-metal-bem` is importable and reports Apple Silicon support. It has no
Burton-Miller operator; the adapter maps that request onto the solver's
complex-wavenumber formulation.

**Open-edge guard.** The Metal solver requires every open edge of a
mirror-reduced mesh to lie on a symmetry plane. A bare horn's mouth rim is a real
free edge, so `SimulationConfig.native_check_open_edges` is cleared for generated
bare waveguides and kept strict everywhere else.

**Run provenance.** Each mesher run writes `hornlab_mesher.json` next to the mesh
(mesher version, formula, mode, units, quadrants, element counts), and the Metal
backend's package version is recorded in solve provenance.

**Two pre-existing macOS test failures** are fixed in the first commit, separate
from the feature work: Windows absolute paths were rewritten relative to the
project on POSIX, and the direct Ath process test needed a pinned platform.

## Dependencies

`hornlab-waveguide-mesher` installs on non-Windows platforms only (it exists to
avoid Wine), and `hornlab-metal-bem` on Apple Silicon macOS only. Both are pinned
public revisions, so **Windows installs download nothing new** — pip skips both
markers. If you would rather they were an opt-in extra than a platform-gated
dependency, say so and I will move them under `[project.optional-dependencies]`;
the code already degrades cleanly when either import fails.

## Validation

On Apple Silicon macOS, Python 3.12:

```text
ruff check .                                          : passed
ruff format --check pyproject.toml scripts src tests  : passed
python -m pytest -q                                   : 715 passed, 13 skipped
```

End-to-end, against the pinned revisions:

- Generated `runs/hornlab_smoke/small_osse.cfg` through the mesher: 220 nodes, 436
  triangles, millimetre units, `SD1D1001` driven tag detected, provenance written.
- Repeated with `Mesh.Quadrants = 1`: 108-triangle quadrant mesh expanded to the
  full 432-triangle model with the expected bounding box, and
  `solver_msh_path_for_symmetry` returns the reduced mesh.
- Solved 1 kHz through `SolveRequest` on `hornlab_metal`: one streamed
  `FrequencyResult`, horizontal polar `(3,)` = `[-1.70, 0.00, -1.59]` dB,
  impedance returned, `convergence_info=0`.

## Also included

Two smaller fixes carried over from the earlier branch, each in its own commit so
they can be dropped independently:

- **Text-only file drops.** macOS Finder drops sometimes arrive as text rather
  than URLs, so the drop handler never saw a path. Falls back to parsing existing
  paths out of dropped text. Also disables the scale spin box for locked
  generated meshes, whose scale is owned by the generator.
- **Plot dB spans.** A manual dB span much wider than the data flattened polar
  traces and collapsed the isobar colour bands. Polar and isobar spans are now
  resolved separately, a manual span leaving under 6 dB of contrast falls back to
  the data range, and a continuous colour norm is used when the data spans less
  than two contour steps. This one is cross-platform and unrelated to the HornLab
  work — say the word and I will pull it back out into its own PR.

Mesh-preview caching from the earlier branch is *not* included.
