### PR TITLE
Fix typos and stray headers in README and User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ While not required, if modeling in Autodesk Fusion, the [Fusion2Msh](https://git
 
 ## Solver Requirements
 
-Boundary Lab currently has 3 selectable BEM solver backends in the application preferences menu. Solve speed is dependant on hardware GPU-based solving is generally the fastest option with 20-30x speed gains over CPU-based solving with typical hardware.
+Boundary Lab currently has 3 selectable BEM solver backends in the application preferences menu. Solve speed is dependent on hardware; GPU-based solving is generally the fastest option with 20-30x speed gains over CPU-based solving with typical hardware.
 
 ### BEAT Engine CUDA GPU Solver Requirements
 
@@ -56,8 +56,6 @@ GPU solving VRAM requirements scale quadratically with mesh element count. Below
 | 15,000 | ~8-12 GB |
 | 20,000 | ~14-20 GB |
 
-##
-
 ### BEAT Engine CPU Solver Requirements
 
 * Intel, AMD, or ARM CPU
@@ -69,16 +67,12 @@ To prepare the Julia environment, from the repository root run:
 julia --project=src/blab/solvers/julia_local -e "using Pkg; Pkg.instantiate()"
 ```
 
-##
-
 ### Bempp CPU Solver Requirements
 
 * Intel or AMD CPU
 * An OpenCL runtime
 
 The [Intel CPU OpenCL runtime](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-cpu-runtime-for-opencl-applications-with-sycl-support.html) is a practical option even on many non-Intel systems.
-
-##
 
 ## Application Installation
 

--- a/docs/User Guide.md
+++ b/docs/User Guide.md
@@ -17,7 +17,7 @@ The Ath script editor contains a text editor for defining Ath shapes. Existing A
 
 <img src="../assets/scripteditor.png" alt="Script Editor" width="300">
 
-Ath scripts can be added, removed, and renamed using the tab controls at the top of the editor pane. To rename a script, double click its tab. Multi-script workflows can be useful for complex multiway designs (see /examples/MultiAth+Mesh_3WayIntegrated), or worflows where you might be comparing outputs on the same script with different values by copy/pasting it into multiple script tabs and enabling/disabling them in the `Mesh Config` window.
+Ath scripts can be added, removed, and renamed using the tab controls at the top of the editor pane. To rename a script, double click its tab. Multi-script workflows can be useful for complex multiway designs (see /examples/MultiAth+Mesh_3WayIntegrated), or workflows where you might be comparing outputs on the same script with different values by copy/pasting it into multiple script tabs and enabling/disabling them in the `Mesh Config` window.
 
 ## 3D Viewport
 


### PR DESCRIPTION
Small documentation cleanup:

- Fix `dependant` → `dependent` and add the missing period in the Solver Requirements section of the README
- Remove three stray `##` empty heading markers that rendered as blank sections between the solver backends
- Fix `worflows` → `workflows` in `docs/User Guide.md`

No functional changes — documentation only.