### PR TITLE
Add condensed CPU solver backend

### DIFF
--- a/scripts/benchmark_coupled_solver.py
+++ b/scripts/benchmark_coupled_solver.py
@@ -45,6 +45,14 @@ def main() -> int:
     parser.add_argument("--singular-order", type=int, default=2)
     parser.add_argument("--precision", choices=("float32", "float64"), default="float64")
     parser.add_argument("--bem-backend", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument(
+        "--condensed",
+        action="store_true",
+        help=(
+            "Select BEAT Engine (CPU Condensed), which eliminates the FEM interior onto the "
+            "interface before the dense solve. CUDA condenses on its own."
+        ),
+    )
     parser.add_argument("--symmetry", choices=("off", "x", "xy"), default="off")
     parser.add_argument(
         "--persistent",
@@ -73,8 +81,16 @@ def main() -> int:
     frequencies = tuple(float(value.strip()) for value in args.frequencies.split(",") if value.strip())
     if not frequencies:
         parser.error("--frequencies must contain at least one value.")
+    if args.condensed and args.bem_backend != "cpu":
+        parser.error("--condensed requires --bem-backend cpu; CUDA already condenses.")
+    # The condensed formulation never forms the monolithic coupled matrix, so the replay
+    # diagnostic has nothing to replay against and the solver rejects the flag outright.
+    if args.condensed and args.mode == "reference":
+        parser.error("--condensed cannot run the reference mode: it has no full-matrix replay.")
     system = _fixture_system() if args.project is None else _system_from_project(args.project)
     modes = ("interactive", "reference", "uncached") if args.mode == "all" else (args.mode,)
+    if args.condensed:
+        modes = tuple(mode for mode in modes if mode != "reference")
     for mode in modes:
         for warmup_index in range(args.warmup_runs):
             _run_mode(
@@ -92,6 +108,7 @@ def main() -> int:
                 precision=args.precision,
                 bem_backend=args.bem_backend,
                 symmetry_mode=args.symmetry,
+                condensed=args.condensed,
             )
         for run_index in range(max(1, args.repeat)):
             _run_mode(
@@ -109,6 +126,7 @@ def main() -> int:
                 precision=args.precision,
                 bem_backend=args.bem_backend,
                 symmetry_mode=args.symmetry,
+                condensed=args.condensed,
             )
     return 0
 
@@ -129,7 +147,14 @@ def _run_mode(
     precision: str,
     bem_backend: str,
     symmetry_mode: str,
+    condensed: bool = False,
 ) -> None:
+    if condensed:
+        backend_id = "beat_cpu_condensed"
+    elif bem_backend == "cuda":
+        backend_id = "beat_cuda"
+    else:
+        backend_id = "beat_cpu"
     prepared = prepare_coupled_ui_solve(
         system,
         freq_min_hz=min(frequencies),
@@ -137,13 +162,13 @@ def _run_mode(
         freq_count=len(frequencies),
         observation_distance_m=2.0,
         polar_angle_step_deg=angle_step,
-        backend_id="beat_cuda" if bem_backend == "cuda" else "beat_cpu",
+        backend_id=backend_id,
         symmetry_mode=symmetry_mode,
     )
     options = dict(prepared.request.solver_options)
     options["quadrature_order"] = int(quadrature_order)
     options["singular_order"] = int(singular_order)
-    options["validation_diagnostics"] = mode != "interactive"
+    options["validation_diagnostics"] = mode != "interactive" and not condensed
     options["cache_frequency_invariant"] = mode != "uncached"
     request = replace(
         prepared.request,
@@ -202,8 +227,9 @@ def _run_mode(
     )
     setup_detail_totals = {key: 0.0 for key in setup_detail_keys}
     print(
-        f"\n{mode.upper()} {phase}={run_index}  precision={precision}  bem={bem_backend}"
-        f"  symmetry={symmetry_mode}  frequencies={len(results)}  wall={wall_s:.3f}s"
+        f"\n{mode.upper()} {phase}={run_index}  backend={backend_id}  precision={precision}"
+        f"  bem={bem_backend}  symmetry={symmetry_mode}  frequencies={len(results)}"
+        f"  wall={wall_s:.3f}s"
     )
     if result_arrival_s:
         print(f"first_result_wall={result_arrival_s[0]:.3f}s")

--- a/src/blab/solvers/coupled_backend.py
+++ b/src/blab/solvers/coupled_backend.py
@@ -272,8 +272,6 @@ class _CoupledBackend:
         solver_options["precision"] = self.precision
         solver_options["bem_backend"] = self.bem_backend
         solver_options["transducer_reference_voltage_v"] = DEFAULT_TRANSDUCER_REFERENCE_VOLTAGE_V
-        if self.bem_backend != "cuda":
-            solver_options["static_condensation"] = False
         typed_request = replace(request, solver_options=solver_options)
         validate_system_capabilities(typed_request)
         return CoupledSession(

--- a/src/blab/solvers/coupled_field.py
+++ b/src/blab/solvers/coupled_field.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from blab.solvers.beat_engine_backend import DEFAULT_BEAT_ENGINE_CUDA_PROJECT, _get_julia_worker
 from blab.solvers.coupled_backend import DEFAULT_COUPLED_CPU_PROJECT, DEFAULT_COUPLED_SOLVER_SCRIPT
-from blab.solvers.registry import normalize_backend_id
+from blab.solvers.registry import normalize_backend_id, supports_physical_system_solves
 
 _FIELD_ARRAYS_FILENAME = "field-arrays.bin"
 _FIELD_RESULT_FILENAME = "field-result.bin"
@@ -41,8 +41,8 @@ def evaluate_bem_field(
     """Evaluate one synthesized BEM response on arbitrary exterior points."""
 
     normalized_backend = normalize_backend_id(backend_id)
-    if normalized_backend not in {"beat_cpu", "beat_cuda"}:
-        raise ValueError("Retained BEM fields require the BEAT Engine CPU or CUDA backend.")
+    if not supports_physical_system_solves(normalized_backend):
+        raise ValueError("Retained BEM fields require the BEAT Engine CPU, CPU Condensed, or CUDA backend.")
     julia_project = (
         DEFAULT_BEAT_ENGINE_CUDA_PROJECT if normalized_backend == "beat_cuda" else DEFAULT_COUPLED_CPU_PROJECT
     )

--- a/src/blab/solvers/julia_local/Manifest.toml
+++ b/src/blab/solvers/julia_local/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "b8e7041f88410617acd8c97d1411f12fa8ea9814"
+project_hash = "7d1a876f6d8670dcf26dfda77f9acad8fa396d12"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -80,6 +80,15 @@ version = "1.11.0"
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
 git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
@@ -99,6 +108,16 @@ git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 version = "1.4.4"
 
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
 git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
@@ -114,6 +133,11 @@ version = "2.8.2"
     Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
     StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
     Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
 
 [[deps.TOML]]
 deps = ["Dates"]

--- a/src/blab/solvers/julia_local/Project.toml
+++ b/src/blab/solvers/julia_local/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/blab/solvers/julia_local/coupled_solver.jl
+++ b/src/blab/solvers/julia_local/coupled_solver.jl
@@ -6,6 +6,8 @@ include(joinpath(@__DIR__, "src", "BeatEngineCore.jl"))
 using .BeatEngineCore
 include(joinpath(@__DIR__, "src", "BeatEngineCoupled.jl"))
 using .BeatEngineCoupled
+include(joinpath(@__DIR__, "src", "BeatEngineCoupledCondensed.jl"))
+using .BeatEngineCoupledCondensed
 
 const DEFAULT_TRANSDUCER_REFERENCE_VOLTAGE_V = 2.83
 const BEM_FIELD_EVALUATION_CACHES = Dict{String,Any}()
@@ -1241,6 +1243,42 @@ function solve_request(request; event_mode=false)
     retained_fem_vertices = sort(
         unique(vcat(interface_map.fem_vertex_indices, transducer_fem_vertices)),
     )
+    # The interface-condensed CPU formulation is a separate solver, not a branch inside the
+    # monolithic one. CUDA condensation still lives in BeatEngineCoupled.
+    use_condensed_solver = static_condensation && bem_backend != :cuda
+    # Adaptive regular quadrature belongs to the condensed solver alone: it is the only path that
+    # keys its quadrature caches per order; the monolithic and CUDA paths always assemble at the
+    # fixed base order.
+    quadrature_selections = if use_condensed_solver
+        mode = lowercase(String(get(solver_options, "regular_quadrature_mode", "fixed")))
+        mode in ("fixed", "wavelength") || error(
+            "Unsupported regular quadrature mode: $mode. Expected fixed or wavelength.",
+        )
+        [
+            mode == "fixed" ?
+            (
+                order=quadrature_order, base_order=quadrature_order, mode=mode,
+                mesh_stat=nothing, area=nothing, length=nothing, kh=nothing,
+                q1_max=nothing, q2_max=nothing,
+            ) :
+            merge(
+                wavelength_quadrature_order(
+                    bem_mesh.areas,
+                    FloatType(frequency_value),
+                    sound_speed,
+                    quadrature_order;
+                    mesh_stat=lowercase(String(get(solver_options, "wavelength_mesh_stat", "p90"))),
+                    q1_max=Float64(get(solver_options, "wavelength_kh_q1_max", 0.0)),
+                    q2_max=Float64(get(solver_options, "wavelength_kh_q2_max", 2.0)),
+                ),
+                (mode=mode,),
+            )
+            for frequency_value in request["frequencies_hz"]
+        ]
+    else
+        nothing
+    end
+
     coupled_cache = nothing
     cache_setup_s = 0.0
     solved_count = 0
@@ -1248,18 +1286,35 @@ function solve_request(request; event_mode=false)
     cancelled && return (cancelled=true, solved_count=solved_count)
     if cache_frequency_invariant
         cache_setup_started = time_ns()
-        coupled_cache = prepare_coupled_cache(
-            fem_mesh,
-            bem_mesh,
-            interface_map;
-            quadrature_order=quadrature_order,
-            singular_order=singular_order,
-            bem_backend=bem_backend,
-            symmetry_mode=symmetry_mode,
-            retained_fem_vertices=retained_fem_vertices,
-            bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
-            wall_impedances=fem_domains.wall_impedances,
-        )
+        coupled_cache = if use_condensed_solver
+            prepare_condensed_coupled_cache(
+                fem_mesh,
+                bem_mesh,
+                interface_map;
+                quadrature_order=quadrature_order,
+                regular_quadrature_orders=sort(
+                    unique(selection.order for selection in quadrature_selections),
+                ),
+                singular_order=singular_order,
+                symmetry_mode=symmetry_mode,
+                retained_fem_vertices=retained_fem_vertices,
+                bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
+                wall_impedances=fem_domains.wall_impedances,
+            )
+        else
+            prepare_coupled_cache(
+                fem_mesh,
+                bem_mesh,
+                interface_map;
+                quadrature_order=quadrature_order,
+                singular_order=singular_order,
+                bem_backend=bem_backend,
+                symmetry_mode=symmetry_mode,
+                retained_fem_vertices=retained_fem_vertices,
+                bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
+                wall_impedances=fem_domains.wall_impedances,
+            )
+        end
         cache_setup_s = (time_ns() - cache_setup_started) / 1.0e9
     end
     outputs = get(request, "outputs", Any[])
@@ -1271,29 +1326,53 @@ function solve_request(request; event_mode=false)
         frequency_hz = FloatType(frequency_value)
         println(stderr, "Coupled $(precision_name)/$(bem_backend): assembling $(frequency_hz) Hz")
         assembly_started = time_ns()
-        coupled_system = build_coupled_system(
-            fem_mesh,
-            bem_mesh,
-            interface_map,
-            frequency_hz,
-            sound_speed,
-            density;
-            quadrature_order=quadrature_order,
-            singular_order=singular_order,
-            cache=coupled_cache,
-            validation_diagnostics=validation_diagnostics,
-            bem_backend=bem_backend,
-            symmetry_mode=symmetry_mode,
-            static_condensation=static_condensation,
-            bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
-            wall_impedances=fem_domains.wall_impedances,
-            transducers=transducers,
-            transducer_operators=transducer_operators,
-            prescribed_bem_normal_velocity=prescribed_bem_normal_velocity,
-        )
+        coupled_system = if use_condensed_solver
+            build_condensed_coupled_system(
+                fem_mesh,
+                bem_mesh,
+                interface_map,
+                frequency_hz,
+                sound_speed,
+                density;
+                quadrature_order=quadrature_order,
+                regular_quadrature_order=quadrature_selections[frequency_index].order,
+                singular_order=singular_order,
+                cache=coupled_cache,
+                validation_diagnostics=validation_diagnostics,
+                symmetry_mode=symmetry_mode,
+                bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
+                wall_impedances=fem_domains.wall_impedances,
+                transducers=transducers,
+                transducer_operators=transducer_operators,
+                prescribed_bem_normal_velocity=prescribed_bem_normal_velocity,
+            )
+        else
+            build_coupled_system(
+                fem_mesh,
+                bem_mesh,
+                interface_map,
+                frequency_hz,
+                sound_speed,
+                density;
+                quadrature_order=quadrature_order,
+                singular_order=singular_order,
+                cache=coupled_cache,
+                validation_diagnostics=validation_diagnostics,
+                bem_backend=bem_backend,
+                symmetry_mode=symmetry_mode,
+                static_condensation=static_condensation,
+                bulk_loss_factor_by_vertex=fem_domains.bulk_loss_factor_by_vertex,
+                wall_impedances=fem_domains.wall_impedances,
+                transducers=transducers,
+                transducer_operators=transducer_operators,
+                prescribed_bem_normal_velocity=prescribed_bem_normal_velocity,
+            )
+        end
         assembly_s = (time_ns() - assembly_started) / 1.0e9
         solve_started = time_ns()
-        solutions = solve_coupled_excitations(coupled_system, excitations)
+        solutions = use_condensed_solver ?
+                    solve_condensed_coupled_excitations(coupled_system, excitations) :
+                    solve_coupled_excitations(coupled_system, excitations)
         solve_s = (time_ns() - solve_started) / 1.0e9
         interface_error_sets = [
             per_interface_errors(
@@ -1506,9 +1585,13 @@ function solve_request(request; event_mode=false)
             "linear_backend" => String(coupled_system.linear_backend),
             "symmetry" => String(symmetry_mode),
             "formulation" => String(coupled_system.formulation),
-            "linear_solver" => coupled_system.formulation == :fem_interface_condensed ?
-                               "cuda_cudss_schur_plus_dense_lu" :
-                               "$(coupled_system.linear_backend)_dense_lu",
+            "linear_solver" => if coupled_system.formulation != :fem_interface_condensed
+                "$(coupled_system.linear_backend)_dense_lu"
+            elseif coupled_system.linear_backend == :cuda
+                "cuda_cudss_schur_plus_dense_lu"
+            else
+                "cpu_umfpack_schur_plus_dense_lu"
+            end,
             "full_system_order" => coupled_system.full_system_order,
             "solved_system_order" => coupled_system.solved_system_order,
             "bounded_region_count" => length(bounded_regions),
@@ -1585,6 +1668,16 @@ function solve_request(request; event_mode=false)
                 solution.all_bem_replay_error for solution in solutions
             )
         end
+        # The condensed counterpart of `relative_residual`: the monolithic coupled matrix does
+        # not exist under condensation, so this is reported unconditionally instead of being
+        # gated behind validation diagnostics. Only the condensed solver produces it.
+        if use_condensed_solver
+            diagnostics["fem_interior_residual"] = maximum(
+                solution.fem_interior_residual for solution in solutions
+            )
+        else
+            diagnostics["fem_interior_residual"] = nothing
+        end
         result = Dict(
             "schema_version" => 1,
             "freq_hz" => frequency_hz,
@@ -1598,10 +1691,17 @@ function solve_request(request; event_mode=false)
             println(JSON.json(result))
         end
         flush(stdout)
-        release_coupled_system!(coupled_system)
+        if use_condensed_solver
+            release_condensed_coupled_system!(coupled_system)
+        else
+            release_coupled_system!(coupled_system)
+        end
         solved_count = frequency_index
     end
-    coupled_cache === nothing || release_coupled_cache!(coupled_cache)
+    if coupled_cache !== nothing
+        use_condensed_solver ? release_condensed_coupled_cache!(coupled_cache) :
+        release_coupled_cache!(coupled_cache)
+    end
     cancelled = cancelled || cancel_requested()
     return (cancelled=cancelled, solved_count=solved_count)
 end

--- a/src/blab/solvers/julia_local/src/BeatEngineCondensedAssembly.jl
+++ b/src/blab/solvers/julia_local/src/BeatEngineCondensedAssembly.jl
@@ -1,0 +1,428 @@
+"""
+Regular Galerkin BEM assembly owned by the condensed coupled solver.
+
+This is a deliberate fork of `assemble_regular_galerkin_operators_cpu` in
+`BeatEngineCpuAssembly.jl`, taken so that assembly can be optimised for this solver without
+touching a file that every other CPU path — exterior, monolithic coupled, and the standalone CLI —
+also runs through.
+
+**This file must stay behaviourally identical to its origin.** `coupled_condensed_tests.jl` pins
+that with a bitwise equivalence test across every symmetry mode; any optimisation added here has to
+keep that test passing.
+
+Only the driver is forked. The element data, quadrature data, colouring, pair accumulators,
+singular corrections and the cache type itself are all reused from `BeatEngineCore` by qualified
+reference: this keeps the duplicated surface to the loop structure that actually needs to change,
+and it means `prepare_coupled_cache` — which builds a `BeatCpuAssemblyCache` — stays fully
+compatible, with no parallel cache type to keep in sync.
+
+The qualified `BeatEngineCore._beat_cpu_*` references are private names, so a rename upstream
+breaks this file; the equivalence test turns that into a loud failure rather than a silent one.
+"""
+
+"""
+    _condensed_accumulate_pair_blocks!(single, adjoint, double, hyper, test_data, trial_data, test_quad, trial_quad, k)
+
+Add one test/trial pair's contribution into caller-owned stack blocks, **without scattering**.
+
+This is the inner quadrature loop of `BeatEngineCore._beat_cpu_accumulate_regular_pair_signed!`
+with the scatter removed, so several contributions to the same pair can be summed before touching
+the operators once. `normal_product` and the curl products are recomputed per contribution because
+reflection changes normals and curls, even though it preserves areas and DOFs.
+"""
+@inline function _condensed_accumulate_pair_blocks!(
+    single_block,
+    adjoint_block,
+    double_block,
+    hyper_block,
+    test_data::BeatEngineCore.BeatCpuElementData{T},
+    trial_data::BeatEngineCore.BeatCpuElementData{T},
+    test_quad::BeatEngineCore.BeatCpuRegularQuadratureData{T},
+    trial_quad::BeatEngineCore.BeatCpuRegularQuadratureData{T},
+    k::T,
+) where {T<:AbstractFloat}
+    normal_product = dot(test_data.normal, trial_data.normal)
+    jac_scale = T(4.0) * test_data.area * trial_data.area
+    curl_products = MMatrix{3,3,T,9}(undef)
+    for local_row in 1:3
+        for local_col in 1:3
+            curl_products[local_row, local_col] = dot(test_data.curls[local_row], trial_data.curls[local_col])
+        end
+    end
+    k2 = k * k
+
+    @inbounds for test_q in eachindex(test_quad.weights)
+        test_basis = test_quad.basis[test_q]
+        x = test_quad.points[test_q]
+        test_weight = test_quad.weights[test_q]
+
+        for trial_q in eachindex(trial_quad.weights)
+            trial_basis = trial_quad.basis[trial_q]
+            y = trial_quad.points[trial_q]
+            r_vec = y - x
+            radius = norm(r_vec)
+            radius == zero(T) && continue
+
+            inv_radius = inv(radius)
+            green = BeatEngineCore._beat_cpu_green(radius, inv_radius, k)
+            grad_scale = green * Complex{T}(-inv_radius, k)
+            trial_dot = dot(r_vec, trial_data.normal) * inv_radius
+            test_dot = -dot(r_vec, test_data.normal) * inv_radius
+            double_value = grad_scale * trial_dot
+            adjoint_value = grad_scale * test_dot
+            weight = test_weight * trial_quad.weights[trial_q] * jac_scale
+            weighted_green = green * weight
+            weighted_double = double_value * weight
+            weighted_adjoint = adjoint_value * weight
+
+            for local_row in 1:3
+                test_value = test_basis[local_row]
+                single_block[local_row] += test_value * weighted_green
+                adjoint_block[local_row] += test_value * weighted_adjoint
+
+                for local_col in 1:3
+                    trial_value = trial_basis[local_col]
+                    basis_product = test_value * trial_value
+                    double_block[local_row, local_col] += basis_product * weighted_double
+                    hyper_block[local_row, local_col] += (
+                        curl_products[local_row, local_col] -
+                        k2 * basis_product * normal_product
+                    ) * weighted_green
+                end
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+    _condensed_accumulate_fused_test!(...)
+
+Sweep one test element's row of the pair space **once**, summing the base contribution and every
+symmetry image into a single stack block per pair before scattering.
+
+This is the whole reason the assembly is forked. The shared implementation walks the entire pair
+space once per image transform, and each pass ends in a 24-entry read-modify-write into four large
+column-strided operators. Those scatters land on the *same* rows and columns every pass, because
+reflection preserves `p1_dofs` and `dp0_dof` — so with `xy` symmetry the operators are traversed
+four times to deposit sums that could have been formed first and deposited once. The scatter is
+latency-bound on a working set far larger than cache, which is why it dominates rather than the
+quadrature: measured cost fits `constant + small * quadrature_points`, with the constant carrying
+most of the time.
+
+**This changes floating-point summation order and is therefore not bitwise identical to the shared
+path when images exist.** In the shared path each pair's contributions reach the operators as four
+separate additions interleaved across whole sweeps; here they arrive as one presummed value. The
+results agree to round-off, and with `symmetry = :off` there are no images so the two remain
+bitwise identical. `coupled_condensed_tests.jl` pins both halves of that statement.
+"""
+function _condensed_accumulate_fused_test!(
+    single_layer,
+    double_layer,
+    adjoint_double_layer,
+    hypersingular,
+    elements,
+    image_element_sets,
+    test_index::Int,
+    trial_indices,
+    k::T,
+    regular_quadrature,
+    image_quadrature_sets,
+) where {T<:AbstractFloat}
+    test_data = elements[test_index]
+    test_quad = regular_quadrature[test_index]
+    single_block = MVector{3,Complex{T}}(undef)
+    adjoint_block = MVector{3,Complex{T}}(undef)
+    double_block = MMatrix{3,3,Complex{T},9}(undef)
+    hyper_block = MMatrix{3,3,Complex{T},9}(undef)
+
+    @inbounds for trial_index in trial_indices
+        trial_data = elements[trial_index]
+        # The base contribution skips self/adjacent pairs, which the singular correction handles
+        # instead. Image contributions never skip: a reflected element is never adjacent to its
+        # own source in the sense that matters here.
+        include_base = !BeatEngineCore.elements_are_adjacent(test_data.face, trial_data.face)
+        isempty(image_element_sets) && !include_base && continue
+
+        fill!(single_block, zero(Complex{T}))
+        fill!(adjoint_block, zero(Complex{T}))
+        fill!(double_block, zero(Complex{T}))
+        fill!(hyper_block, zero(Complex{T}))
+
+        if include_base
+            _condensed_accumulate_pair_blocks!(
+                single_block, adjoint_block, double_block, hyper_block,
+                test_data, trial_data, test_quad, regular_quadrature[trial_index], k,
+            )
+        end
+        for image_index in eachindex(image_element_sets)
+            _condensed_accumulate_pair_blocks!(
+                single_block, adjoint_block, double_block, hyper_block,
+                test_data, image_element_sets[image_index][trial_index],
+                test_quad, image_quadrature_sets[image_index][trial_index], k,
+            )
+        end
+
+        # One scatter for the base and every image together. Reflection preserves the DOFs, so the
+        # base element's indices are the correct destination for all of them.
+        for local_row in 1:3
+            row = test_data.p1_dofs[local_row]
+            single_layer[row, trial_data.dp0_dof] += single_block[local_row]
+            adjoint_double_layer[row, trial_data.dp0_dof] += adjoint_block[local_row]
+            for local_col in 1:3
+                col = trial_data.p1_dofs[local_col]
+                double_layer[row, col] += double_block[local_row, local_col]
+                hypersingular[row, col] += hyper_block[local_row, local_col]
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+    assemble_condensed_regular_operators(mesh, p1_space, dp0_space, k, rule; ...)
+
+Assemble the four Burton-Miller boundary operators for the condensed solver.
+
+Mirrors `assemble_regular_galerkin_operators_cpu` argument for argument and returns the same
+NamedTuple, so the call site is a drop-in swap.
+"""
+function assemble_condensed_regular_operators(
+    mesh::BoundaryMesh{T},
+    p1_space::P1Space,
+    dp0_space::DP0Space,
+    k::T,
+    rule::TriangleRule{T};
+    skip_singular::Bool=true,
+    singular_order::Int=2,
+    element_indices=eachindex(mesh.faces),
+    threaded::Bool=true,
+    timing=nothing,
+    singular_cache=nothing,
+    cpu_cache=nothing,
+    symmetry_mode::Symbol=:off,
+) where {T<:AbstractFloat}
+    symmetry_mode = BeatEngineCore.normalized_symmetry_mode(symmetry_mode)
+
+    if cpu_cache !== nothing
+        cpu_cache.symmetry_mode == symmetry_mode || error("CPU assembly cache symmetry mode does not match the requested mode.")
+        cpu_cache.singular_order == singular_order || error("CPU assembly cache singular order does not match the requested order.")
+        # Pointer identity, not value equality: `TriangleRule` defines no `==`. Strict on purpose.
+        cpu_cache.rule == rule || error("CPU assembly cache quadrature rule does not match the requested rule.")
+    end
+
+    indices = cpu_cache === nothing ? collect(element_indices) : cpu_cache.indices
+    p1_count = p1_space.global_dof_count
+    dp0_count = dp0_space.global_dof_count
+    single_layer = zeros(Complex{T}, p1_count, dp0_count)
+    double_layer = zeros(Complex{T}, p1_count, p1_count)
+    adjoint_double_layer = zeros(Complex{T}, p1_count, dp0_count)
+    hypersingular = zeros(Complex{T}, p1_count, p1_count)
+    elements = cpu_cache === nothing ?
+               BeatEngineCore._beat_cpu_element_data(mesh, p1_space, dp0_space) :
+               cpu_cache.elements
+    regular_quadrature = cpu_cache === nothing ?
+                         BeatEngineCore._beat_cpu_regular_quadrature_data(mesh, rule) :
+                         cpu_cache.regular_quadrature
+    adjacent_pairs = cpu_cache === nothing ?
+                     BeatEngineCore.count_adjacent_pairs(mesh, indices) :
+                     cpu_cache.adjacent_pairs
+    regular_pairs = length(indices) * length(indices) - adjacent_pairs
+    threaded_enabled = cpu_cache === nothing ? threaded && Threads.nthreads() > 1 : cpu_cache.threaded_enabled
+    color_groups = Vector{Vector{Int}}()
+    color_build_elapsed = @elapsed begin
+        color_groups = if cpu_cache === nothing
+            threaded_enabled ? BeatEngineCore._beat_cpu_element_color_groups(mesh, indices) : [indices]
+        else
+            cpu_cache.color_groups
+        end
+    end
+    timing !== nothing && (timing["regular_operator_cpu_color_build"] = color_build_elapsed)
+    image_transforms = cpu_cache === nothing ?
+                       collect(BeatEngineCore.symmetry_image_transforms(symmetry_mode)) :
+                       cpu_cache.image_transforms
+
+    # Materialise every image's reflected data up front so the fused sweep can visit all of them
+    # per pair. With a cache these are already built and this is just aliasing.
+    image_element_sets = [
+        cpu_cache === nothing ?
+        BeatEngineCore._beat_cpu_reflect_element_data(elements, transform) :
+        cpu_cache.image_elements[transform_index]
+        for (transform_index, transform) in enumerate(image_transforms)
+    ]
+    image_quadrature_sets = [
+        cpu_cache === nothing ?
+        BeatEngineCore._beat_cpu_reflect_regular_quadrature_data(regular_quadrature, transform) :
+        cpu_cache.image_quadrature[transform_index]
+        for (transform_index, transform) in enumerate(image_transforms)
+    ]
+
+    regular_elapsed = @elapsed begin
+        # One pass over the pair space instead of one per image. See
+        # `_condensed_accumulate_fused_test!` for why this is the fork's whole purpose.
+        if threaded_enabled
+            for group in color_groups
+                Threads.@threads for group_index in eachindex(group)
+                    _condensed_accumulate_fused_test!(
+                        single_layer,
+                        double_layer,
+                        adjoint_double_layer,
+                        hypersingular,
+                        elements,
+                        image_element_sets,
+                        group[group_index],
+                        indices,
+                        k,
+                        regular_quadrature,
+                        image_quadrature_sets,
+                    )
+                end
+            end
+        else
+            for test_index in indices
+                _condensed_accumulate_fused_test!(
+                    single_layer,
+                    double_layer,
+                    adjoint_double_layer,
+                    hypersingular,
+                    elements,
+                    image_element_sets,
+                    test_index,
+                    indices,
+                    k,
+                    regular_quadrature,
+                    image_quadrature_sets,
+                )
+            end
+        end
+    end
+    timing !== nothing && (timing["regular_operator_cpu_scatter"] = regular_elapsed)
+
+    singular_pairs = 0
+    skipped_pairs = adjacent_pairs
+
+    if !skip_singular
+        cache = singular_cache === nothing ?
+                build_singular_correction_cache(mesh, singular_order, indices) :
+                singular_cache
+        singular_elapsed = @elapsed begin
+            if threaded_enabled
+                for group in color_groups
+                    Threads.@threads for group_index in eachindex(group)
+                        test_index = group[group_index]
+                        BeatEngineCore._beat_cpu_accumulate_singular_test!(
+                            single_layer,
+                            double_layer,
+                            adjoint_double_layer,
+                            hypersingular,
+                            elements,
+                            cache.pairs_by_test[test_index],
+                            cache.rules,
+                            k,
+                        )
+                    end
+                end
+            else
+                for test_index in indices
+                    BeatEngineCore._beat_cpu_accumulate_singular_test!(
+                        single_layer,
+                        double_layer,
+                        adjoint_double_layer,
+                        hypersingular,
+                        elements,
+                        cache.pairs_by_test[test_index],
+                        cache.rules,
+                        k,
+                    )
+                end
+            end
+        end
+        timing !== nothing && (timing["singular_corrections_cpu_scatter"] = singular_elapsed)
+        singular_pairs = cache.pair_count
+        skipped_pairs = 0
+    else
+        timing !== nothing && (timing["singular_corrections_cpu_scatter"] = 0.0)
+    end
+
+    image_singular_pairs = 0
+    image_singular_elapsed = @elapsed begin
+        if !skip_singular
+            for (transform_index, transform) in enumerate(image_transforms)
+                image_cache = cpu_cache === nothing ?
+                    BeatEngineCore._beat_cpu_image_singular_cache(mesh, singular_order, indices, transform) :
+                    cpu_cache.image_singular_caches[transform_index]
+                image_singular_pairs += image_cache.pair_count
+                image_cache.pair_count == 0 && continue
+                image_elements = cpu_cache === nothing ?
+                    BeatEngineCore._beat_cpu_reflect_element_data(elements, transform) :
+                    cpu_cache.image_elements[transform_index]
+                image_quadrature = cpu_cache === nothing ?
+                    BeatEngineCore._beat_cpu_reflect_regular_quadrature_data(regular_quadrature, transform) :
+                    cpu_cache.image_quadrature[transform_index]
+                if threaded_enabled
+                    for group in color_groups
+                        Threads.@threads for group_index in eachindex(group)
+                            test_index = group[group_index]
+                            BeatEngineCore._beat_cpu_accumulate_image_singular_delta_test!(
+                                single_layer,
+                                double_layer,
+                                adjoint_double_layer,
+                                hypersingular,
+                                elements,
+                                image_elements,
+                                image_cache.pairs_by_test[test_index],
+                                image_cache.rules,
+                                k,
+                                regular_quadrature,
+                                image_quadrature,
+                            )
+                        end
+                    end
+                else
+                    for test_index in indices
+                        BeatEngineCore._beat_cpu_accumulate_image_singular_delta_test!(
+                            single_layer,
+                            double_layer,
+                            adjoint_double_layer,
+                            hypersingular,
+                            elements,
+                            image_elements,
+                            image_cache.pairs_by_test[test_index],
+                            image_cache.rules,
+                            k,
+                            regular_quadrature,
+                            image_quadrature,
+                        )
+                    end
+                end
+            end
+        end
+    end
+    timing !== nothing && (timing["image_singular_corrections_cpu_scatter"] = image_singular_elapsed)
+
+    BeatEngineCore._beat_cpu_apply_operator_p1_row_weights!(
+        (
+            single_layer=single_layer,
+            double_layer=double_layer,
+            adjoint_double_layer=adjoint_double_layer,
+            hypersingular=hypersingular,
+        ),
+        mesh,
+        symmetry_mode,
+    )
+
+    return (
+        single_layer=single_layer,
+        double_layer=double_layer,
+        adjoint_double_layer=adjoint_double_layer,
+        hypersingular=hypersingular,
+        regular_pairs=regular_pairs + length(image_transforms) * length(indices) * length(indices),
+        singular_pairs=singular_pairs,
+        skipped_pairs=skipped_pairs,
+        image_singular_pairs=image_singular_pairs,
+        cpu_color_count=length(color_groups),
+        on_gpu=false,
+        regular_kernel_mode=threaded_enabled ? "cpu_colored_threads" : "cpu_serial",
+        regular_assembly_mode=threaded_enabled ? :cpu_colored_threads : :cpu_serial,
+    )
+end

--- a/src/blab/solvers/julia_local/src/BeatEngineCoupledCondensed.jl
+++ b/src/blab/solvers/julia_local/src/BeatEngineCoupledCondensed.jl
@@ -1,0 +1,1000 @@
+"""
+    BeatEngineCoupledCondensed
+
+Standalone CPU coupled FEM-BEM solver that eliminates the FEM interior onto the retained
+interface before the dense solve.
+
+`BeatEngineCoupled` assembles the entire coupled system densely, FEM volume block included.
+That block is a P1 tetrahedral Helmholtz operator with roughly fifteen nonzeros per row, so
+the monolithic formulation materializes a matrix that is about 0.06% dense and then takes a
+dense LU of it. This solver instead forms the Schur complement
+
+    S = A_ΓΓ - A_ΓI * A_II⁻¹ * A_IΓ
+
+on the retained set `Γ = interface ∪ transducer surfaces`, and solves a system whose order is
+`|Γ| + |BEM| + |interface| + 2 * |transducers|` rather than one that carries every interior
+FEM vertex.
+
+This is a deliberate fork of the monolithic solver rather than a branch inside it: the two are
+expected to diverge further. It duplicates the coupled assembly rather than sharing it, and in
+exchange carries no CUDA paths, no validation-diagnostic paths, and no monolithic formulation.
+It reuses `BeatEngineCoupled` only for mesh types, cache preparation, and operator assembly —
+the physics inputs, not the solve.
+
+Precision is mixed on purpose. `A_II` is factored in `ComplexF64` whatever `T` is, and only the
+assembled `S` is demoted to `Complex{T}`. `S` has poles at the eigenvalues of `A_II` — the
+cavity modes with a pressure-release interface — and near one of those the loss of digits scales
+like `1/η` in the bulk loss factor. `η = 0` is both the default and a shipped configuration, so
+the interior solve carries the double-precision margin unconditionally. The interior is sparse,
+which makes that margin nearly free.
+"""
+module BeatEngineCoupledCondensed
+
+using LinearAlgebra, SparseArrays, StaticArrays, Statistics
+using ..BeatEngineCore
+using ..BeatEngineCoupled
+
+include(joinpath(@__DIR__, "BeatEngineCondensedAssembly.jl"))
+
+export assemble_condensed_regular_operators,
+    wavelength_quadrature_order,
+    prepare_condensed_coupled_cache,
+    release_condensed_coupled_cache!,
+    build_condensed_coupled_system,
+    release_condensed_coupled_system!,
+    solve_condensed_coupled_excitations,
+    solve_condensed_coupled_system,
+    solve_condensed_coupled_systems
+
+"""
+    _interior_partition(fem_system, interface_operators, retained_vertices)
+
+Split FEM vertices into the eliminated interior and the retained set `Γ`, enforcing the
+structural precondition that makes condensation valid: interface loads must have no support on
+interior vertices. If they did, eliminating the interior would have to carry a flux contribution
+into the retained/flux block, which this assembly does not form.
+"""
+function _interior_partition(
+    fem_system::SparseMatrixCSC,
+    interface_operators::InterfaceOperators,
+    retained_vertices,
+)
+    fem_count = size(fem_system, 1)
+    retained = Int.(collect(retained_vertices))
+    retained_set = Set(retained)
+    interior = [vertex for vertex in 1:fem_count if !(vertex in retained_set)]
+    nnz(interface_operators.fem_load[interior, :]) == 0 || error(
+        "FEM static condensation currently requires interface loads to have support only on interface nodes.",
+    )
+    return interior, retained
+end
+
+"""
+    _densify_sparse_columns!(dense, source, columns)
+
+Scatter `source[:, columns]` into `dense`, which must be at least as wide as `columns`.
+
+`source[:, columns]` would build a whole intermediate `SparseMatrixCSC` before densifying it;
+this writes the nonzeros straight into a buffer the caller reuses across blocks, which keeps the
+Schur sweep from allocating two large arrays per block per task.
+"""
+function _densify_sparse_columns!(
+    dense::AbstractMatrix{ComplexF64},
+    source::SparseMatrixCSC{ComplexF64},
+    columns,
+)
+    fill!(dense, zero(ComplexF64))
+    row_indices = rowvals(source)
+    values = nonzeros(source)
+    for (local_column, source_column) in enumerate(columns)
+        for index in nzrange(source, source_column)
+            dense[row_indices[index], local_column] = values[index]
+        end
+    end
+    return dense
+end
+
+"""
+    _schur_block_width(requested, retained_count) -> Int
+
+Narrow `requested` until `Γ` splits into at least one block per thread, so the column sweep never
+leaves threads idle. Never widens past `requested`, and never returns less than one.
+
+`fld` rather than `cld`: the guarantee is on the block *count*, `cld(retained_count, width)`. Ten
+columns across eight threads need a width of one to reach eight blocks -- `cld(10, 8)` is 2, which
+yields five.
+"""
+function _schur_block_width(requested::Int, retained_count::Int)
+    return max(1, min(requested, fld(retained_count, Threads.nthreads())))
+end
+
+"""
+    _build_condensation(fem_system, interface_operators, retained_vertices)
+
+Factor the FEM interior with UMFPACK and form the dense Schur complement.
+
+`S` is returned unnegated, in the same sign convention as `fem_system`, so it fills exactly the
+slot the monolithic formulation fills with the full FEM block.
+
+`A_IΓ` is densified a block of columns at a time rather than all at once: a transducer-heavy `Γ`
+makes `interior_count × retained_count` a multi-gigabyte intermediate.
+
+The blocks are swept in parallel. UMFPACK's solve is one triangular pair per right-hand side with
+no BLAS-3 step and no internal threading, so the sweep dominates condensation by well over an
+order of magnitude relative to the sparse factorization it consumes, and only the task split
+scales it. Each block owns a disjoint column slice of the accumulator, so the only shared mutable
+state is the factorization, which is split per task rather than locked.
+
+`schur_block_columns` is not a BLAS-3 tile size: the solve is per column whatever the block width,
+so a wide block buys no arithmetic and only costs locality. Peak scratch is
+`2 * interior_count * schur_block_columns` complex entries *per task*; wide blocks measure no
+faster than narrow ones for several times the scratch, so the default stays narrow.
+
+The requested width is an upper bound, not the width used: `_schur_block_width` narrows it until
+`Γ` splits into at least one block per thread. Without that, occupancy depends on the size of the
+interface: a 500-node interface under a 256-column block yields two blocks, and six of eight
+threads idle through the phase that dominates condensation.
+"""
+function _build_condensation(
+    fem_system::SparseMatrixCSC{Complex{T}},
+    interface_operators::InterfaceOperators{T},
+    retained_vertices;
+    schur_block_columns::Int=32,
+) where {T<:AbstractFloat}
+    schur_block_columns > 0 || error("Schur block column count must be positive.")
+    interior_vertices, retained = _interior_partition(
+        fem_system,
+        interface_operators,
+        retained_vertices,
+    )
+    interior_count = length(interior_vertices)
+    retained_count = length(retained)
+
+    interior_system = SparseMatrixCSC{ComplexF64,Int}(fem_system[interior_vertices, interior_vertices])
+    interior_retained = SparseMatrixCSC{ComplexF64,Int}(fem_system[interior_vertices, retained])
+    retained_interior = SparseMatrixCSC{ComplexF64,Int}(fem_system[retained, interior_vertices])
+
+    # UMFPACK performs symbolic and numeric factorization in one call, so the whole cost lands
+    # in `factorization_s` and the analysis slot stays zero.
+    factorization_started = time_ns()
+    factorization = lu(interior_system)
+    factorization_s = (time_ns() - factorization_started) / 1.0e9
+
+    schur_started = time_ns()
+    accumulator = Matrix{ComplexF64}(fem_system[retained, retained])
+    block_columns = _schur_block_width(schur_block_columns, retained_count)
+    block_starts = collect(1:block_columns:retained_count)
+    # One factorization handle and one pair of scratch buffers per *task*, never per thread:
+    # `Threads.threadid()` is not stable across a yield on Julia >= 1.8, so a threadid-indexed
+    # pool can hand the same workspace to two live tasks. `copy(::UmfpackLU)` is the split
+    # UMFPACK documents for concurrent solves -- it shares the symbolic and numeric handles,
+    # which a solve only reads, and gives each copy its own workspace, control, info and lock,
+    # so the copies never contend. `lu` above already ran the numeric factorization, so no copy
+    # re-factors and none of them race to populate it.
+    task_count = max(1, min(Threads.nthreads(), length(block_starts)))
+    # A block wider than Γ would otherwise have every task allocate scratch for columns that do
+    # not exist.
+    buffer_columns = min(block_columns, retained_count)
+    tasks = map(1:task_count) do task_index
+        Threads.@spawn begin
+            task_factorization = copy(factorization)
+            dense_columns = Matrix{ComplexF64}(undef, interior_count, buffer_columns)
+            solved_columns = Matrix{ComplexF64}(undef, interior_count, buffer_columns)
+            for block_index in task_index:task_count:length(block_starts)
+                block_start = block_starts[block_index]
+                columns = block_start:min(block_start + block_columns - 1, retained_count)
+                # The final block is short, so the buffers are used a prefix at a time.
+                block_rhs = view(dense_columns, :, 1:length(columns))
+                block_solution = view(solved_columns, :, 1:length(columns))
+                _densify_sparse_columns!(block_rhs, interior_retained, columns)
+                ldiv!(block_solution, task_factorization, block_rhs)
+                # Disjoint column slices: each block is the sole writer of its own columns.
+                mul!(
+                    view(accumulator, :, columns),
+                    retained_interior,
+                    block_solution,
+                    -one(ComplexF64),
+                    one(ComplexF64),
+                )
+            end
+        end
+    end
+    foreach(wait, tasks)
+    schur = Complex{T}.(accumulator)
+    schur_extraction_s = (time_ns() - schur_started) / 1.0e9
+
+    return (
+        factorization=factorization,
+        interior_system=interior_system,
+        interior_retained=interior_retained,
+        retained_interior=retained_interior,
+        schur=schur,
+        interior_vertices=interior_vertices,
+        retained_vertices=retained,
+        interior_count=interior_count,
+        retained_count=retained_count,
+        # The width actually swept, not the one requested.
+        schur_block_columns=block_columns,
+        timings=(
+            analysis_s=0.0,
+            factorization_s=factorization_s,
+            schur_extraction_s=schur_extraction_s,
+        ),
+    )
+end
+
+function _release_condensation!(condensation)
+    isnothing(condensation) && return nothing
+    # UMFPACK holds its factors outside the Julia heap; release them with the system rather than
+    # waiting for the finalizer, so a frequency sweep does not accumulate them.
+    finalize(condensation.factorization)
+    return nothing
+end
+
+"""
+    _forward_schur(condensation, fem_rhs) -> (reduced_rhs, interior_rhs)
+
+Reduce a FEM right-hand side onto `Γ`: `g_Γ = f_Γ - A_ΓI * A_II⁻¹ * f_I`. `f_I` is returned
+because the backward substitution needs it and nothing else retains it.
+"""
+function _forward_schur(condensation, fem_rhs::AbstractMatrix{Complex{T}}) where {T<:AbstractFloat}
+    interior_rhs = ComplexF64.(fem_rhs[condensation.interior_vertices, :])
+    retained_rhs = ComplexF64.(fem_rhs[condensation.retained_vertices, :])
+    mul!(
+        retained_rhs,
+        condensation.retained_interior,
+        condensation.factorization \ interior_rhs,
+        -one(ComplexF64),
+        one(ComplexF64),
+    )
+    return Complex{T}.(retained_rhs), interior_rhs
+end
+
+"""
+    _backward_schur(condensation, interior_rhs, retained_pressure)
+        -> (fem_pressure, interior_residual)
+
+Recover the eliminated interior, `u_I = A_II⁻¹ (f_I - A_IΓ u_Γ)`, and return the full FEM
+pressure in mesh vertex order.
+
+`interior_residual` is `‖A_II u_I + A_IΓ u_Γ - f_I‖` per excitation, relative to the largest of
+those three terms. It costs one sparse matvec over blocks retained for the backward solve anyway.
+
+It is normalized against the largest term rather than against `f_I` alone because a
+voltage-driven transducer forces the system entirely through the electrical rows, leaving `f_I`
+identically zero; dividing by `eps` there turns a converged solve into an O(1) reading.
+
+Note what it does *not* measure: it validates the back-substitution, not the conditioning of
+`S`. Near an interior resonance the recovered pressure can be visibly wrong while this residual
+stays at round-off, so it is not a resonance detector.
+"""
+function _backward_schur(
+    condensation,
+    interior_rhs,
+    retained_pressure::AbstractMatrix{Complex{T}},
+) where {T<:AbstractFloat}
+    retained_double = ComplexF64.(retained_pressure)
+    interior_pressure = condensation.factorization \
+                        (interior_rhs - condensation.interior_retained * retained_double)
+    interior_term = condensation.interior_system * interior_pressure
+    retained_term = condensation.interior_retained * retained_double
+    residual = interior_term + retained_term - interior_rhs
+
+    interior_residual = zeros(T, size(residual, 2))
+    for column in axes(residual, 2)
+        scale = max(
+            norm(view(interior_term, :, column)),
+            norm(view(retained_term, :, column)),
+            norm(view(interior_rhs, :, column)),
+            eps(Float64),
+        )
+        interior_residual[column] = T(norm(view(residual, :, column)) / scale)
+    end
+
+    fem_pressure = zeros(
+        Complex{T},
+        condensation.interior_count + condensation.retained_count,
+        size(retained_pressure, 2),
+    )
+    fem_pressure[condensation.interior_vertices, :] = Complex{T}.(interior_pressure)
+    fem_pressure[condensation.retained_vertices, :] = retained_pressure
+    return fem_pressure, interior_residual
+end
+
+"""
+    wavelength_quadrature_order(areas, frequency_hz, sound_speed, base_order; ...)
+
+Pick this frequency's regular quadrature order from `kh` against a mesh element-size statistic,
+where `h = sqrt(area_stat)` and `kh = 2*pi*f/c * h`.
+
+Owned by this solver rather than shared with the exterior path: this is the only solver that keys
+its quadrature caches per order, and the exterior loop holds its device caches at a single rule.
+
+`q1_max` defaults to 0.0, which disables the one-point tier -- `kh <= 0.0` is false for any
+positive frequency. That tier is off deliberately. The hypersingular kernel decays like 1/r^3, so
+its regular-pair integrand is far less smooth than the single layer's and a centroid rule
+approximates it poorly; enabling it needs its own convergence study, not a default.
+"""
+function wavelength_quadrature_order(
+    areas,
+    frequency_hz::Real,
+    sound_speed::Real,
+    base_order::Int;
+    mesh_stat::AbstractString="p90",
+    q1_max::Real=0.0,
+    q2_max::Real=2.0,
+)
+    q1_cutoff = Float64(q1_max)
+    q2_cutoff = Float64(q2_max)
+    q1_cutoff >= 0.0 || error("wavelength_kh_q1_max must be non-negative.")
+    q2_cutoff > q1_cutoff || error("wavelength_kh_q2_max must exceed wavelength_kh_q1_max.")
+    values = collect(Float64.(areas))
+    isempty(values) && error("Cannot select wavelength quadrature order from an empty mesh.")
+    area = if mesh_stat == "median"
+        median(values)
+    elseif mesh_stat == "p75"
+        quantile(values, 0.75)
+    elseif mesh_stat == "p90"
+        quantile(values, 0.90)
+    elseif mesh_stat == "max"
+        maximum(values)
+    else
+        error("Unsupported wavelength mesh stat: $mesh_stat. Expected median, p75, p90, or max.")
+    end
+    element_length = sqrt(area)
+    kh = Float64(2pi * frequency_hz / sound_speed) * element_length
+    order = kh <= q1_cutoff ? 1 : kh <= q2_cutoff ? 2 : base_order
+    return (
+        order=order,
+        base_order=base_order,
+        mesh_stat=mesh_stat,
+        area=area,
+        length=element_length,
+        kh=kh,
+        q1_max=q1_cutoff,
+        q2_max=q2_cutoff,
+    )
+end
+
+"""
+    _condensed_quadrature_bundle(bem_mesh, p1, dp0, order; singular_order, symmetry_mode)
+
+Build the order-dependent half of a coupled cache for one quadrature order.
+
+`BeatEngineCoupled.prepare_coupled_cache` is used unmodified for everything that does not depend
+on the regular rule -- the FEM matrices, interface operators, P1/DP0 spaces and singular caches.
+This adds only the parts that do, from the same public constructors that cache uses, so a
+frequency sweep that changes order rebuilds those and nothing else.
+
+The bundle owns its rule. `assemble_regular_galerkin_operators_cpu` compares `cpu_cache.rule` to
+the rule it is handed, and `TriangleRule` defines no `==`, so that comparison is pointer identity.
+It is a strict stale-cache guard and it only holds while a rule and the assembly cache built from
+it travel together.
+"""
+function _condensed_quadrature_bundle(
+    bem_mesh::BoundaryMesh{T},
+    p1::P1Space,
+    dp0::DP0Space,
+    order::Int;
+    singular_order::Int,
+    symmetry_mode::Symbol,
+) where {T<:AbstractFloat}
+    rule = triangle_rule(T, order)
+
+    assembly_started = time_ns()
+    cpu_assembly_cache = build_beat_cpu_assembly_cache(
+        bem_mesh,
+        p1,
+        dp0,
+        rule;
+        singular_order=singular_order,
+        symmetry_mode=symmetry_mode,
+    )
+    bem_cpu_assembly_cache_s = (time_ns() - assembly_started) / 1.0e9
+
+    identity_started = time_ns()
+    # The identity rule is clamped to order 2 and never follows a q1 regular rule down.
+    # `l2_identity_element_matrix` integrates a degree-2 polynomial (P1xP1) or degree-1
+    # (P1xDP0), and the 3-point order-2 rule is degree-2 exact -- so every order >= 2 gives
+    # identical matrices, but the 1-point centroid rule does not: it returns area/9 uniformly
+    # where the exact block is area/6 on the diagonal and area/12 off it. That would silently
+    # degrade the Burton-Miller 0.5*I term rather than fail.
+    identity_rule = order >= 2 ? rule : triangle_rule(T, 2)
+    identity_p1_p1 = assemble_l2_identity_matrix(
+        bem_mesh, p1, dp0, identity_rule, :p1, :p1; symmetry_mode=symmetry_mode,
+    )
+    identity_p1_dp0 = assemble_l2_identity_matrix(
+        bem_mesh, p1, dp0, identity_rule, :p1, :dp0; symmetry_mode=symmetry_mode,
+    )
+    bem_identity_cache_s = (time_ns() - identity_started) / 1.0e9
+
+    field_started = time_ns()
+    field_cache = build_field_evaluation_cache(bem_mesh, rule; symmetry_mode=symmetry_mode)
+    field_cache_s = (time_ns() - field_started) / 1.0e9
+
+    return (
+        order=order,
+        rule=rule,
+        cpu_assembly_cache=cpu_assembly_cache,
+        identity_p1_p1=identity_p1_p1,
+        identity_p1_dp0=identity_p1_dp0,
+        field_cache=field_cache,
+        timings=(
+            bem_cpu_assembly_cache_s=bem_cpu_assembly_cache_s,
+            bem_identity_cache_s=bem_identity_cache_s,
+            field_cache_s=field_cache_s,
+        ),
+    )
+end
+
+"""
+    prepare_condensed_coupled_cache(fem_mesh, bem_mesh, interface_map; regular_quadrature_orders, ...)
+
+Wrap an unmodified `BeatEngineCoupled.prepare_coupled_cache` with one quadrature bundle per order
+the sweep will select.
+
+Every order is built eagerly. Coupled frequencies are not solved in ascending order -- the
+live-plotting order emits both endpoints first and then the interior in van der Corput order -- so
+a lazily grown cache would reach peak memory on the second frequency solved rather than at setup,
+after the user has already seen a result and believes the run is healthy.
+"""
+function prepare_condensed_coupled_cache(
+    fem_mesh::VolumeMesh{T},
+    bem_mesh::BoundaryMesh{T},
+    interface_map::ConformingInterfaceMap;
+    quadrature_order::Int=2,
+    regular_quadrature_orders=nothing,
+    singular_order::Int=2,
+    symmetry_mode::Symbol=:off,
+    retained_fem_vertices=interface_map.fem_vertex_indices,
+    bulk_loss_factor_by_vertex=zeros(T, length(fem_mesh.vertices)),
+    wall_impedances=NamedTuple[],
+) where {T<:AbstractFloat}
+    base = prepare_coupled_cache(
+        fem_mesh,
+        bem_mesh,
+        interface_map;
+        quadrature_order=quadrature_order,
+        singular_order=singular_order,
+        bem_backend=:cpu,
+        symmetry_mode=symmetry_mode,
+        retained_fem_vertices=retained_fem_vertices,
+        bulk_loss_factor_by_vertex=bulk_loss_factor_by_vertex,
+        wall_impedances=wall_impedances,
+    )
+    # The base order is always carried, whether or not any frequency selects it: with the q1 tier
+    # enabled and a base order of 4, every frequency can select 1 or 2 and leave the base out of
+    # the requested set. The base bundle is free anyway -- it aliases what `prepare_coupled_cache`
+    # already built -- and `build_condensed_coupled_system` validates requests against
+    # `base_quadrature_order`, so the cache has to be able to answer for it regardless.
+    requested = isnothing(regular_quadrature_orders) ? Int[] :
+                Int.(collect(regular_quadrature_orders))
+    all(order -> order >= 1, requested) ||
+        error("Condensed coupled regular quadrature orders must be positive.")
+    orders = sort(unique(vcat(requested, quadrature_order)))
+    bundles = Dict{Int,Any}()
+    # The base order's bundle is what `prepare_coupled_cache` already built; reusing those fields
+    # keeps a single-order sweep byte-identical to calling the plain cache directly.
+    bundles[quadrature_order] = (
+        order=quadrature_order,
+        rule=base.rule,
+        cpu_assembly_cache=base.cpu_assembly_cache,
+        identity_p1_p1=base.identity_p1_p1,
+        identity_p1_dp0=base.identity_p1_dp0,
+        field_cache=base.field_cache,
+    )
+    for order in orders
+        order == quadrature_order && continue
+        bundles[order] = _condensed_quadrature_bundle(
+            bem_mesh,
+            base.p1,
+            base.dp0,
+            order;
+            singular_order=singular_order,
+            symmetry_mode=base.symmetry_mode,
+        )
+    end
+    # Extra bundles are real setup cost, so fold them into the fields the caller already reports
+    # rather than leaving a mixed-order sweep looking as cheap as a single-order one. Field names
+    # match `prepare_coupled_cache`'s timings exactly, so `cache.timings` reads the same either way.
+    extra = [bundle.timings for (order, bundle) in bundles if order != quadrature_order]
+    timings = merge(
+        base.timings,
+        (
+            bem_cpu_assembly_cache_s=base.timings.bem_cpu_assembly_cache_s +
+                                     sum(t -> t.bem_cpu_assembly_cache_s, extra; init=0.0),
+            bem_identity_cache_s=base.timings.bem_identity_cache_s +
+                                 sum(t -> t.bem_identity_cache_s, extra; init=0.0),
+            field_cache_s=base.timings.field_cache_s +
+                          sum(t -> t.field_cache_s, extra; init=0.0),
+        ),
+    )
+    return (
+        base=base,
+        quadrature_bundles=bundles,
+        base_quadrature_order=quadrature_order,
+        singular_order=singular_order,
+        timings=timings,
+    )
+end
+
+function release_condensed_coupled_cache!(cache)
+    # CPU only, so the bundles hold host memory that the collector reclaims; the base cache still
+    # owns whatever `prepare_coupled_cache` allocated.
+    release_coupled_cache!(cache.base)
+    return nothing
+end
+
+"""
+    build_condensed_coupled_system(fem_mesh, bem_mesh, interface_map, frequency_hz, sound_speed, density; ...)
+
+Assemble and factor the interface-condensed coupled system on the CPU.
+
+Mirrors `BeatEngineCoupled.build_coupled_system` in inputs and in the fields callers read, but
+always produces the `:fem_interface_condensed` formulation and never the monolithic one.
+
+`cache` is a `prepare_condensed_coupled_cache` result. `regular_quadrature_order` selects which of its
+bundles to assemble with, defaulting to the cache's base order.
+"""
+function build_condensed_coupled_system(
+    fem_mesh::VolumeMesh{T},
+    bem_mesh::BoundaryMesh{T},
+    interface_map::ConformingInterfaceMap,
+    frequency_hz::T,
+    sound_speed::T,
+    density::T;
+    quadrature_order::Int=2,
+    regular_quadrature_order::Union{Nothing,Int}=nothing,
+    singular_order::Int=2,
+    cache=nothing,
+    validation_diagnostics::Bool=false,
+    symmetry_mode::Symbol=:off,
+    bulk_loss_factor::T=zero(T),
+    bulk_loss_factor_by_vertex=nothing,
+    wall_impedances=NamedTuple[],
+    transducers::AbstractVector{ElectrodynamicTransducer{T}}=ElectrodynamicTransducer{T}[],
+    transducer_operators=nothing,
+    prescribed_bem_normal_velocity=nothing,
+    schur_block_columns::Int=32,
+) where {T<:AbstractFloat}
+    # `relative_residual` needs the monolithic coupled matrix, which this formulation never
+    # forms. `fem_interior_residual` on each solution is the condensed-appropriate check.
+    validation_diagnostics && error(
+        "FEM static condensation cannot be combined with full-matrix validation diagnostics.",
+    )
+
+    fem_stage_started = time_ns()
+    resolved_transducer_operators = isnothing(transducer_operators) ?
+                                    assemble_transducer_operators(fem_mesh, bem_mesh, transducers) :
+                                    transducer_operators
+    transducer_fem_vertices = isempty(transducers) ?
+                              Int[] :
+                              unique(findnz(resolved_transducer_operators.fem_surface)[1])
+    retained_fem_vertices = sort(
+        unique(vcat(interface_map.fem_vertex_indices, transducer_fem_vertices)),
+    )
+    # Without a cache, build one for exactly the order this frequency selected, so the uncached
+    # path honours the selection instead of silently falling back to the base order.
+    selected_quadrature_order = isnothing(regular_quadrature_order) ? quadrature_order :
+                                regular_quadrature_order
+    condensed_cache = isnothing(cache) ? prepare_condensed_coupled_cache(
+        fem_mesh,
+        bem_mesh,
+        interface_map;
+        quadrature_order=selected_quadrature_order,
+        singular_order=singular_order,
+        symmetry_mode=symmetry_mode,
+        retained_fem_vertices=retained_fem_vertices,
+        bulk_loss_factor_by_vertex=(
+            isnothing(bulk_loss_factor_by_vertex) ?
+            fill(bulk_loss_factor, length(fem_mesh.vertices)) :
+            bulk_loss_factor_by_vertex
+        ),
+        wall_impedances=wall_impedances,
+    ) : cache
+    if !isnothing(cache)
+        # Orders are compared as integers. `TriangleRule` defines no `==`, so comparing rules here
+        # would fall back to `===` on their vectors and never hold for a freshly built rule. A
+        # cache we built above is correct by construction, so only a supplied one is checked.
+        condensed_cache.singular_order == singular_order ||
+            error("Condensed coupled cache singular order does not match the requested singular order.")
+        condensed_cache.base_quadrature_order == quadrature_order ||
+            error("Condensed coupled cache base quadrature order does not match the requested quadrature order.")
+    end
+    bundle = get(condensed_cache.quadrature_bundles, selected_quadrature_order, nothing)
+    isnothing(bundle) && error(
+        "Condensed coupled cache holds no quadrature bundle for order $selected_quadrature_order; " *
+        "it was built for $(sort(collect(keys(condensed_cache.quadrature_bundles)))).",
+    )
+    # The selected bundle's fields shadow the base cache's, so everything below reads the cache
+    # exactly as it did before per-order quadrature existed.
+    prepared = merge(condensed_cache.base, bundle)
+    prepared.bem_backend == :cpu ||
+        error("Condensed coupled cache must be built for the CPU BEM backend.")
+    prepared.symmetry_mode == BeatEngineCore.normalized_symmetry_mode(symmetry_mode) ||
+        error("Coupled cache symmetry mode does not match requested symmetry.")
+    prepared.retained_fem_vertices == retained_fem_vertices ||
+        error("Coupled cache retained FEM vertices do not match the current moving surfaces.")
+
+    omega = T(2pi) * frequency_hz
+    wavenumber = omega / sound_speed
+    fem_system = assemble_fem_dynamic_stiffness(
+        prepared.stiffness,
+        prepared.mass,
+        wavenumber;
+        bulk_loss_mass=prepared.bulk_loss_mass,
+    )
+    wall_admittances = Complex{T}[
+        miki_rigid_backed_surface_admittance(
+            frequency_hz,
+            sound_speed,
+            density,
+            operator.thickness_m,
+            operator.flow_resistivity_pa_s_per_m2,
+        )
+        for operator in prepared.wall_impedance_operators
+    ]
+    for (operator, admittance) in zip(prepared.wall_impedance_operators, wall_admittances)
+        fem_system -= Complex{T}(0, density * omega) * admittance .* operator.matrix
+    end
+    interface_operators = prepared.interface_operators
+    transducer_count = length(transducers)
+    size(resolved_transducer_operators.fem_surface, 2) == transducer_count ||
+        error("FEM transducer operator count does not match the transducer list.")
+    size(resolved_transducer_operators.bem_surface, 2) == transducer_count ||
+        error("BEM transducer operator count does not match the transducer list.")
+    normal_derivative_scale = Complex{T}(0, density * omega)
+    bem_motion_flux = normal_derivative_scale .* Complex{T}.(
+        resolved_transducer_operators.bem_normal_velocity
+    )
+    resolved_prescribed_bem_velocity = isnothing(prescribed_bem_normal_velocity) ?
+                                       spzeros(T, length(bem_mesh.faces), 0) :
+                                       T.(prescribed_bem_normal_velocity)
+    size(resolved_prescribed_bem_velocity, 1) == length(bem_mesh.faces) ||
+        error("Prescribed BEM normal velocity must contain one row per BEM face.")
+    bem_prescribed_neumann = normal_derivative_scale .* Complex{T}.(resolved_prescribed_bem_velocity)
+    prescribed_bem_count = size(bem_prescribed_neumann, 2)
+    fem_system_s = (time_ns() - fem_stage_started) / 1.0e9
+
+    bem_operator_started = time_ns()
+    # This solver's own fork of the CPU regular assembly, so it can be optimised without
+    # touching the shared path every other backend runs through. Behaviourally identical to
+    # `assemble_regular_galerkin_operators(...; backend=:cpu)`, pinned by an equivalence test.
+    operators = assemble_condensed_regular_operators(
+        bem_mesh,
+        prepared.p1,
+        prepared.dp0,
+        wavenumber,
+        prepared.rule;
+        skip_singular=false,
+        singular_order=singular_order,
+        singular_cache=prepared.singular_cache,
+        cpu_cache=prepared.cpu_assembly_cache,
+        symmetry_mode=prepared.symmetry_mode,
+    )
+    bem_operator_s = (time_ns() - bem_operator_started) / 1.0e9
+
+    bem_matrix_started = time_ns()
+    bem_lhs, bem_rhs_operator = burton_miller_neumann_matrices(
+        operators,
+        prepared.identity_p1_p1,
+        prepared.identity_p1_dp0,
+        wavenumber,
+    )
+    bem_interface_block = -(bem_rhs_operator * Complex{T}.(interface_operators.bem_flux))
+    bem_motion_block = transducer_count == 0 ? nothing : -(bem_rhs_operator * bem_motion_flux)
+    bem_prescribed_rhs = prescribed_bem_count == 0 ?
+                         zeros(Complex{T}, length(bem_mesh.vertices), 0) :
+                         Complex{T}.(bem_rhs_operator * bem_prescribed_neumann)
+    bem_matrix_s = (time_ns() - bem_matrix_started) / 1.0e9
+
+    condensation_started = time_ns()
+    condensation = _build_condensation(
+        fem_system,
+        interface_operators,
+        retained_fem_vertices;
+        schur_block_columns=schur_block_columns,
+    )
+    fem_condensation_s = (time_ns() - condensation_started) / 1.0e9
+
+    block_assembly_started = time_ns()
+    fem_count = length(fem_mesh.vertices)
+    bem_count = length(bem_mesh.vertices)
+    interface_count = length(interface_map.fem_vertex_indices)
+    retained_fem_count = length(retained_fem_vertices)
+    gamma_range = 1:retained_fem_count
+    bem_range = (retained_fem_count + 1):(retained_fem_count + bem_count)
+    flux_range = (retained_fem_count + bem_count + 1):(retained_fem_count + bem_count + interface_count)
+    acoustic_system_count = retained_fem_count + bem_count + interface_count
+    mechanical_range = transducer_count == 0 ?
+                       (1:0) :
+                       ((acoustic_system_count + 1):(acoustic_system_count + transducer_count))
+    electrical_range = transducer_count == 0 ?
+                       (1:0) :
+                       (
+        (acoustic_system_count + transducer_count + 1):
+        (acoustic_system_count + 2 * transducer_count)
+    )
+    system_count = acoustic_system_count + 2 * transducer_count
+    mechanical_impedance = Complex{T}[
+        Complex{T}(
+            transducer.rms_n_s_per_m,
+            -omega * transducer.mmd_kg + inv(omega * transducer.cms_m_per_n),
+        )
+        for transducer in transducers
+    ]
+    electrical_impedance = Complex{T}[
+        Complex{T}(transducer.re_ohm, -omega * transducer.le_h)
+        for transducer in transducers
+    ]
+    force_factor = T[transducer.bl_n_per_a for transducer in transducers]
+
+    coupled = zeros(Complex{T}, system_count, system_count)
+    # The Schur complement takes the slot the full FEM block occupies in the monolithic
+    # formulation, and the interface coupling is restricted to Γ.
+    coupled[gamma_range, gamma_range] = condensation.schur
+    coupled[gamma_range, flux_range] =
+        -Complex{T}.(Matrix(interface_operators.fem_load[retained_fem_vertices, :]))
+    coupled[flux_range, gamma_range] =
+        Complex{T}.(Matrix(interface_operators.fem_trace[:, retained_fem_vertices]))
+    coupled[bem_range, bem_range] = bem_lhs
+    coupled[bem_range, flux_range] = bem_interface_block
+    coupled[flux_range, bem_range] = -Complex{T}.(Matrix(interface_operators.bem_trace))
+    if transducer_count > 0
+        coupled[gamma_range, mechanical_range] =
+            -normal_derivative_scale .* Complex{T}.(
+                Matrix(resolved_transducer_operators.fem_surface[retained_fem_vertices, :])
+            )
+        coupled[bem_range, mechanical_range] = bem_motion_block
+        coupled[mechanical_range, gamma_range] =
+            -Complex{T}.(
+                transpose(
+                    Matrix(resolved_transducer_operators.fem_force[retained_fem_vertices, :]),
+                )
+            )
+        coupled[mechanical_range, bem_range] =
+            Complex{T}.(transpose(Matrix(resolved_transducer_operators.bem_force)))
+        coupled[mechanical_range, mechanical_range] = Matrix(Diagonal(mechanical_impedance))
+        coupled[mechanical_range, electrical_range] =
+            -Matrix(Diagonal(Complex{T}.(force_factor)))
+        coupled[electrical_range, mechanical_range] = Matrix(Diagonal(Complex{T}.(force_factor)))
+        coupled[electrical_range, electrical_range] = Matrix(Diagonal(electrical_impedance))
+    end
+    block_assembly_s = (time_ns() - block_assembly_started) / 1.0e9
+
+    coupled_factorization_started = time_ns()
+    factorization = lu!(coupled)
+    coupled_factorization_s = (time_ns() - coupled_factorization_started) / 1.0e9
+
+    return (
+        fem_mesh=fem_mesh,
+        bem_mesh=bem_mesh,
+        interface_map=interface_map,
+        interface_operators=interface_operators,
+        transducers=transducers,
+        transducer_operators=resolved_transducer_operators,
+        density=density,
+        bulk_loss_factor=maximum(prepared.bulk_loss_factor_by_vertex; init=zero(T)),
+        bulk_loss_factor_by_vertex=prepared.bulk_loss_factor_by_vertex,
+        wall_admittances=wall_admittances,
+        omega=omega,
+        wavenumber=wavenumber,
+        field_cache=prepared.field_cache,
+        coupled=nothing,
+        factorization=factorization,
+        formulation=:fem_interface_condensed,
+        # The order the assembly actually used, so diagnostics report what ran, not what was asked.
+        regular_quadrature_order=selected_quadrature_order,
+        condensation=condensation,
+        fem_range=1:fem_count,
+        gamma_range=gamma_range,
+        retained_fem_vertices=retained_fem_vertices,
+        bem_range=bem_range,
+        flux_range=flux_range,
+        mechanical_range=mechanical_range,
+        electrical_range=electrical_range,
+        bem_lhs=nothing,
+        bem_factorization=nothing,
+        bem_rhs_operator=nothing,
+        prescribed_bem_rhs=bem_prescribed_rhs,
+        prescribed_bem_neumann=bem_prescribed_neumann,
+        bem_backend=:cpu,
+        linear_backend=:cpu,
+        symmetry_mode=prepared.symmetry_mode,
+        cache=condensed_cache,
+        owns_cache=isnothing(cache),
+        validation_diagnostics=false,
+        scalar_type=T,
+        full_system_order=fem_count + bem_count + interface_count + 2 * transducer_count,
+        solved_system_order=system_count,
+        timings=(
+            fem_system_s=fem_system_s,
+            bem_operator_s=bem_operator_s,
+            bem_matrix_s=bem_matrix_s,
+            fem_condensation_s=fem_condensation_s,
+            block_assembly_s=block_assembly_s,
+            coupled_factorization_s=coupled_factorization_s,
+            replay_factorization_s=0.0,
+        ),
+    )
+end
+
+function release_condensed_coupled_system!(system)
+    _release_condensation!(system.condensation)
+    system.owns_cache && release_condensed_coupled_cache!(system.cache)
+    return nothing
+end
+
+function _solution_from_parts(
+    system,
+    fem_pressure,
+    bem_pressure,
+    interface_flux,
+    fem_interior_residual;
+    diaphragm_velocity=zeros(Complex{system.scalar_type}, length(system.transducers)),
+    voice_coil_current=zeros(Complex{system.scalar_type}, length(system.transducers)),
+    prescribed_bem_neumann=zeros(Complex{system.scalar_type}, length(system.bem_mesh.faces)),
+)
+    T = system.scalar_type
+    bem_neumann = (
+        Complex{T}.(system.interface_operators.bem_flux) * interface_flux +
+        Complex{T}(0, system.density * system.omega) .*
+        (Complex{T}.(system.transducer_operators.bem_normal_velocity) * diaphragm_velocity) +
+        prescribed_bem_neumann
+    )
+
+    pressure_jump = (
+        system.interface_operators.fem_trace * fem_pressure -
+        system.interface_operators.bem_trace * bem_pressure
+    )
+    pressure_scale = max(
+        norm(system.interface_operators.fem_trace * fem_pressure),
+        norm(system.interface_operators.bem_trace * bem_pressure),
+        eps(T),
+    )
+    fem_integrated_flux = zero(Complex{T})
+    bem_integrated_flux_along_fem_normal = zero(Complex{T})
+    interface_dof = Dict(
+        vertex => index
+        for (index, vertex) in enumerate(system.interface_map.fem_vertex_indices)
+    )
+    for local_face_index in eachindex(system.interface_map.fem_face_indices)
+        fem_face = system.fem_mesh.boundary_faces[system.interface_map.fem_face_indices[local_face_index]]
+        fem_flux_average = sum(interface_flux[interface_dof[vertex]] for vertex in fem_face) / T(3)
+        bem_face_index = system.interface_map.bem_face_indices[local_face_index]
+        fem_integrated_flux +=
+            BeatEngineCoupled._triangle_area(system.fem_mesh.vertices, fem_face) * fem_flux_average
+        bem_integrated_flux_along_fem_normal += (
+            T(system.interface_map.normal_sign[local_face_index]) *
+            system.bem_mesh.areas[bem_face_index] *
+            bem_neumann[bem_face_index]
+        )
+    end
+    flux_scale = max(abs(fem_integrated_flux), abs(bem_integrated_flux_along_fem_normal), eps(T))
+    return (
+        fem_pressure=fem_pressure,
+        bem_pressure=bem_pressure,
+        interface_flux=interface_flux,
+        bem_neumann=bem_neumann,
+        diaphragm_velocity=diaphragm_velocity,
+        voice_coil_current=voice_coil_current,
+        relative_residual=nothing,
+        fem_interior_residual=fem_interior_residual,
+        pressure_continuity_error=norm(pressure_jump) / pressure_scale,
+        flux_conservation_error=abs(fem_integrated_flux - bem_integrated_flux_along_fem_normal) / flux_scale,
+        all_bem_replay_error=nothing,
+        interface_map=system.interface_map,
+        interface_operators=system.interface_operators,
+    )
+end
+
+function solve_condensed_coupled_excitations(system, excitations)
+    T = system.scalar_type
+    requested = collect(excitations)
+    isempty(requested) && error("At least one coupled excitation is required.")
+    excitation_count = length(requested)
+    fem_rhs = zeros(Complex{T}, length(system.fem_mesh.vertices), excitation_count)
+    bem_rhs = zeros(Complex{T}, length(system.bem_mesh.vertices), excitation_count)
+    prescribed_bem_neumann = zeros(Complex{T}, length(system.bem_mesh.faces), excitation_count)
+    electrical_rhs = zeros(Complex{T}, length(system.transducers), excitation_count)
+    for (column, excitation) in enumerate(requested)
+        kind = Symbol(excitation.kind)
+        amplitude = Complex{T}(excitation.amplitude)
+        if kind == :normal_velocity
+            fem_boundary_tags = hasproperty(excitation, :fem_boundary_tags) ?
+                                Int.(excitation.fem_boundary_tags) :
+                                [Int(excitation.radiator_tag)]
+            fem_boundary_weights = hasproperty(excitation, :fem_boundary_weights) ?
+                                   T.(excitation.fem_boundary_weights) :
+                                   ones(T, length(fem_boundary_tags))
+            length(fem_boundary_tags) == length(fem_boundary_weights) ||
+                error("Prescribed FEM boundary tags and weights must have the same length.")
+            all(weight -> isfinite(weight) && weight > zero(T), fem_boundary_weights) ||
+                error("Prescribed FEM boundary weights must be finite and greater than zero.")
+            for (tag, weight) in zip(fem_boundary_tags, fem_boundary_weights)
+                fem_rhs[:, column] .+= assemble_prescribed_velocity_load(
+                    system.fem_mesh,
+                    tag,
+                    system.density,
+                    system.omega,
+                    amplitude * weight,
+                )
+            end
+            bem_source_index = hasproperty(excitation, :bem_source_index) ?
+                               Int(excitation.bem_source_index) :
+                               0
+            if bem_source_index > 0
+                bem_source_index <= size(system.prescribed_bem_rhs, 2) ||
+                    error("Prescribed BEM source index $bem_source_index is unavailable.")
+                bem_rhs[:, column] .= amplitude .* view(system.prescribed_bem_rhs, :, bem_source_index)
+                prescribed_bem_neumann[:, column] .=
+                    amplitude .* view(system.prescribed_bem_neumann, :, bem_source_index)
+            end
+            isempty(fem_boundary_tags) && bem_source_index == 0 && error(
+                "A prescribed-velocity excitation must own at least one FEM or BEM moving boundary.",
+            )
+        elseif kind == :voltage
+            transducer_index = Int(excitation.transducer_index)
+            1 <= transducer_index <= length(system.transducers) ||
+                error("Voltage excitation references invalid transducer index $transducer_index.")
+            electrical_rhs[transducer_index, column] = amplitude
+        else
+            error("Unsupported coupled excitation kind: $kind.")
+        end
+    end
+
+    rhs = zeros(Complex{T}, size(system.factorization, 1), excitation_count)
+    rhs[system.bem_range, :] = bem_rhs
+    rhs[system.electrical_range, :] = electrical_rhs
+    reduced_rhs, interior_rhs = _forward_schur(system.condensation, fem_rhs)
+    rhs[system.gamma_range, :] = reduced_rhs
+    solution = system.factorization \ rhs
+    fem_pressure, fem_interior_residual = _backward_schur(
+        system.condensation,
+        interior_rhs,
+        solution[system.gamma_range, :],
+    )
+    return [
+        _solution_from_parts(
+            system,
+            fem_pressure[:, column],
+            solution[system.bem_range, column],
+            solution[system.flux_range, column],
+            fem_interior_residual[column];
+            diaphragm_velocity=solution[system.mechanical_range, column],
+            voice_coil_current=solution[system.electrical_range, column],
+            prescribed_bem_neumann=prescribed_bem_neumann[:, column],
+        )
+        for column in axes(fem_pressure, 2)
+    ]
+end
+
+function solve_condensed_coupled_systems(system, radiator_tags; radiator_velocities=nothing)
+    T = system.scalar_type
+    tags = Int.(collect(radiator_tags))
+    isempty(tags) && error("At least one radiator tag is required.")
+    velocities = isnothing(radiator_velocities) ?
+                 fill(Complex{T}(1, 0), length(tags)) :
+                 Complex{T}.(collect(radiator_velocities))
+    length(velocities) == length(tags) ||
+        error("Radiator tags and velocities must have the same length.")
+    return solve_condensed_coupled_excitations(
+        system,
+        [
+            (kind=:normal_velocity, radiator_tag=tag, transducer_index=0, amplitude=velocity)
+            for (tag, velocity) in zip(tags, velocities)
+        ],
+    )
+end
+
+function solve_condensed_coupled_system(system, radiator_tag::Int; radiator_velocity=ComplexF64(1, 0))
+    return only(
+        solve_condensed_coupled_systems(
+            system,
+            [radiator_tag];
+            radiator_velocities=[radiator_velocity],
+        ),
+    )
+end
+
+end # module

--- a/src/blab/solvers/julia_local/tests/coupled_condensed_tests.jl
+++ b/src/blab/solvers/julia_local/tests/coupled_condensed_tests.jl
@@ -1,0 +1,766 @@
+include(joinpath(@__DIR__, "..", "src", "BeatEngineCoupledCondensed.jl"))
+using .BeatEngineCoupled
+using .BeatEngineCoupledCondensed
+using LinearAlgebra, Random, SparseArrays, StaticArrays
+
+const CONDENSED_FIXTURE_ROOT = normpath(joinpath(@__DIR__, "..", "..", "..", "..", "..", "tests", "fixtures"))
+const CONDENSED_QUADRATURE_ORDER = parse(Int, get(ENV, "BLAB_COUPLED_QUADRATURE_ORDER", "1"))
+const CONDENSED_SINGULAR_ORDER = parse(Int, get(ENV, "BLAB_COUPLED_SINGULAR_ORDER", "1"))
+
+function condensed_synthetic_case(
+    ::Type{T};
+    vertex_count::Int=60,
+    retained_count::Int=10,
+    density::Float64=0.08,
+    interior_load::Bool=false,
+) where {T<:AbstractFloat}
+    Random.seed!(20260814)
+    retained = sort(randperm(vertex_count)[1:retained_count])
+    # Diagonally dominant so the interior block is safely invertible and the manufactured
+    # solution isolates the condensation algebra rather than conditioning.
+    system = SparseMatrixCSC{Complex{T},Int}(
+        sprand(Complex{T}, vertex_count, vertex_count, density) +
+        Complex{T}(vertex_count / 4) * I,
+    )
+    load_rows = interior_load ? vcat(retained[2:end], first(setdiff(1:vertex_count, retained))) : retained
+    fem_load = sparse(load_rows, 1:retained_count, ones(T, retained_count), vertex_count, retained_count)
+    operators = InterfaceOperators(
+        fem_load,
+        spzeros(T, 4, retained_count),
+        spzeros(T, retained_count, vertex_count),
+        spzeros(T, retained_count, 4),
+    )
+    return system, operators, retained
+end
+
+@testset "Schur condensation algebra" begin
+    system, operators, retained = condensed_synthetic_case(Float64)
+    vertex_count = size(system, 1)
+    interior = setdiff(1:vertex_count, retained)
+
+    condensation = BeatEngineCoupledCondensed._build_condensation(system, operators, retained)
+
+    @test condensation.interior_count == length(interior)
+    @test condensation.retained_count == length(retained)
+    @test condensation.interior_vertices == interior
+    @test condensation.retained_vertices == retained
+    @test eltype(condensation.schur) == ComplexF64
+    @test size(condensation.schur) == (length(retained), length(retained))
+
+    # The Schur complement is unnegated, in the same sign convention as `system`. Computed here
+    # independently and densely.
+    expected_schur = (
+        Matrix(system[retained, retained]) -
+        Matrix(system[retained, interior]) *
+        (Matrix(system[interior, interior]) \ Matrix(system[interior, retained]))
+    )
+    @test condensation.schur ≈ expected_schur rtol = 1e-10
+
+    # Manufactured solution: plant u = 1, form f = A u, and require the full round trip
+    # (forward -> reduced dense solve -> backward) to recover it.
+    planted = ones(ComplexF64, vertex_count, 1)
+    forcing = Matrix(system * planted)
+    reduced_rhs, interior_rhs = BeatEngineCoupledCondensed._forward_schur(condensation, forcing)
+    @test size(reduced_rhs) == (length(retained), 1)
+    recovered, interior_residual = BeatEngineCoupledCondensed._backward_schur(
+        condensation,
+        interior_rhs,
+        condensation.schur \ reduced_rhs,
+    )
+    @test size(recovered) == (vertex_count, 1)
+    @test norm(recovered - planted) / norm(planted) < 1e-10
+    @test length(interior_residual) == 1
+    @test maximum(interior_residual) < 1e-10
+
+    # Two excitations at once, the second scaled, must scale linearly.
+    multi_forcing = hcat(forcing, 0.5 .* forcing)
+    multi_reduced, multi_interior = BeatEngineCoupledCondensed._forward_schur(condensation, multi_forcing)
+    multi_recovered, multi_residual = BeatEngineCoupledCondensed._backward_schur(
+        condensation,
+        multi_interior,
+        condensation.schur \ multi_reduced,
+    )
+    @test norm(multi_recovered[:, 1] - planted[:, 1]) / norm(planted) < 1e-10
+    @test norm(multi_recovered[:, 2] - 0.5 .* planted[:, 1]) / norm(planted) < 1e-10
+    @test length(multi_residual) == 2
+    @test maximum(multi_residual) < 1e-10
+
+    # A voltage-driven transducer forces the coupled system entirely through the electrical
+    # rows, so the FEM interior sees f_I = 0. The residual must stay at round-off there rather
+    # than normalizing against nothing.
+    gamma_only_forcing = zeros(ComplexF64, vertex_count, 1)
+    gamma_only_forcing[retained, 1] .= 1 .+ 0.5im
+    @test iszero(gamma_only_forcing[interior, 1])
+    gamma_reduced, gamma_interior = BeatEngineCoupledCondensed._forward_schur(
+        condensation,
+        gamma_only_forcing,
+    )
+    gamma_recovered, gamma_residual = BeatEngineCoupledCondensed._backward_schur(
+        condensation,
+        gamma_interior,
+        condensation.schur \ gamma_reduced,
+    )
+    @test maximum(gamma_residual) < 1e-10
+    # With f_I = 0 the interior rows must annihilate the recovered solution, so measure that
+    # absolutely against the solution magnitude rather than against the zero forcing.
+    @test norm(system[interior, :] * gamma_recovered[:, 1]) / norm(gamma_recovered[:, 1]) < 1e-10
+    @test norm(gamma_recovered[:, 1]) > 0
+
+    # The chunked column sweep runs one task per block against its own copy of the UMFPACK
+    # factorization, so the partition must not move the answer. Every column is solved and
+    # accumulated independently of the block it lands in, which makes the agreement exact and not
+    # merely close -- two tasks sharing a solve workspace could not survive that. Run this file
+    # under `julia -t <n>` for the comparison to actually cover concurrent tasks; at the default
+    # single thread it still checks that the block partition itself is neutral.
+    single_shot = BeatEngineCoupledCondensed._build_condensation(
+        system,
+        operators,
+        retained;
+        schur_block_columns=length(retained),
+    )
+    narrow = BeatEngineCoupledCondensed._build_condensation(
+        system,
+        operators,
+        retained;
+        schur_block_columns=3,
+    )
+    # One block per column: more blocks than threads, so the tasks stride over several each.
+    per_column = BeatEngineCoupledCondensed._build_condensation(
+        system,
+        operators,
+        retained;
+        schur_block_columns=1,
+    )
+    @test single_shot.schur ≈ condensation.schur rtol = 1e-12
+    @test narrow.schur ≈ condensation.schur rtol = 1e-12
+    @test single_shot.schur == condensation.schur
+    @test narrow.schur == condensation.schur
+    @test per_column.schur == condensation.schur
+    # A block wider than Γ is clamped to it rather than overrunning the accumulator.
+    wide = BeatEngineCoupledCondensed._build_condensation(
+        system,
+        operators,
+        retained;
+        schur_block_columns=4 * length(retained),
+    )
+    @test wide.schur == condensation.schur
+    # The requested width is an upper bound. It is narrowed until Γ splits into at least one
+    # block per thread, so no thread sits idle through the sweep whatever the interface size.
+    # Stated as a property because the answer depends on the thread count this file is run under.
+    for requested in (1, 3, length(retained), 4 * length(retained))
+        built = BeatEngineCoupledCondensed._build_condensation(
+            system,
+            operators,
+            retained;
+            schur_block_columns=requested,
+        )
+        @test built.schur == condensation.schur
+        @test 1 <= built.schur_block_columns <= requested
+        @test cld(length(retained), built.schur_block_columns) >=
+              min(Threads.nthreads(), length(retained))
+    end
+    @test_throws ErrorException BeatEngineCoupledCondensed._build_condensation(
+        system,
+        operators,
+        retained;
+        schur_block_columns=0,
+    )
+
+    # Mixed precision: the interior is factored in ComplexF64 whatever T is, and only the
+    # assembled Schur complement is demoted.
+    system32, operators32, retained32 = condensed_synthetic_case(Float32)
+    condensation32 = BeatEngineCoupledCondensed._build_condensation(system32, operators32, retained32)
+    @test eltype(condensation32.schur) == ComplexF32
+    @test eltype(condensation32.interior_system) == ComplexF64
+    @test eltype(condensation32.factorization) == ComplexF64
+    planted32 = ones(ComplexF32, size(system32, 1), 1)
+    forcing32 = Matrix(system32 * planted32)
+    reduced32, interior32 = BeatEngineCoupledCondensed._forward_schur(condensation32, forcing32)
+    @test eltype(reduced32) == ComplexF32
+    recovered32, residual32 = BeatEngineCoupledCondensed._backward_schur(
+        condensation32,
+        interior32,
+        condensation32.schur \ reduced32,
+    )
+    @test eltype(recovered32) == ComplexF32
+    @test norm(recovered32 - planted32) / norm(planted32) < 1e-4
+    @test eltype(residual32) == Float32
+    @test maximum(residual32) < 1e-5
+
+    # The structural guard that makes the condensation valid: interface loads must not touch
+    # eliminated interior vertices.
+    violating_system, violating_operators, violating_retained =
+        condensed_synthetic_case(Float64; interior_load=true)
+    @test_throws ErrorException BeatEngineCoupledCondensed._build_condensation(
+        violating_system,
+        violating_operators,
+        violating_retained,
+    )
+end
+
+if get(ENV, "BLAB_RUN_COUPLED_REFERENCE", "0") == "1"
+    @testset "Condensed coupled solver matches monolithic" begin
+        fem_mesh = load_gmsh41_volume(joinpath(CONDENSED_FIXTURE_ROOT, "femvolume.msh"), 0.001)
+        bem_mesh = load_gmsh22_with_tags(joinpath(CONDENSED_FIXTURE_ROOT, "exterior_conforming.msh"), 0.001)
+        interface_map = build_conforming_interface_map(
+            fem_mesh,
+            bem_mesh,
+            physical_tag(fem_mesh, 2, "Interface"),
+            2,
+        )
+        radiator_tag = physical_tag(fem_mesh, 2, "Radiator")
+        fem_mesh32 = load_gmsh41_volume(joinpath(CONDENSED_FIXTURE_ROOT, "femvolume.msh"), Float32(0.001))
+        bem_mesh32 = load_gmsh22_with_tags(
+            joinpath(CONDENSED_FIXTURE_ROOT, "exterior_conforming.msh"),
+            Float32(0.001),
+        )
+        interface_map32 = build_conforming_interface_map(
+            fem_mesh32,
+            bem_mesh32,
+            physical_tag(fem_mesh32, 2, "Interface"),
+            2,
+        )
+
+        function monolithic_system(::Type{T}, frequency; transducers=ElectrodynamicTransducer{T}[]) where {T}
+            mesh, boundary, mapping = T === Float32 ?
+                                      (fem_mesh32, bem_mesh32, interface_map32) :
+                                      (fem_mesh, bem_mesh, interface_map)
+            return build_coupled_system(
+                mesh,
+                boundary,
+                mapping,
+                T(frequency),
+                T(343.0),
+                T(1.21);
+                quadrature_order=CONDENSED_QUADRATURE_ORDER,
+                singular_order=CONDENSED_SINGULAR_ORDER,
+                validation_diagnostics=false,
+                bem_backend=:cpu,
+                transducers=transducers,
+            )
+        end
+
+        function condensed_system_at(::Type{T}, frequency; transducers=ElectrodynamicTransducer{T}[]) where {T}
+            mesh, boundary, mapping = T === Float32 ?
+                                      (fem_mesh32, bem_mesh32, interface_map32) :
+                                      (fem_mesh, bem_mesh, interface_map)
+            return build_condensed_coupled_system(
+                mesh,
+                boundary,
+                mapping,
+                T(frequency),
+                T(343.0),
+                T(1.21);
+                quadrature_order=CONDENSED_QUADRATURE_ORDER,
+                singular_order=CONDENSED_SINGULAR_ORDER,
+                transducers=transducers,
+            )
+        end
+
+        relative_error(reference, candidate) = norm(
+            ComplexF64.(candidate) .- ComplexF64.(reference),
+        ) / norm(ComplexF64.(reference))
+
+        monolithic = monolithic_system(Float64, 500.0)
+        condensed = condensed_system_at(Float64, 500.0)
+        try
+            @test monolithic.formulation == :monolithic
+            @test condensed.formulation == :fem_interface_condensed
+            @test condensed.solved_system_order < condensed.full_system_order
+            @test condensed.full_system_order == monolithic.full_system_order
+            @test condensed.linear_backend == :cpu
+            @test eltype(condensed.condensation.schur) == ComplexF64
+            @test condensed.condensation.retained_count == length(interface_map.fem_vertex_indices)
+
+            reference = only(solve_coupled_systems(monolithic, [radiator_tag]))
+            candidates = solve_condensed_coupled_systems(
+                condensed,
+                [radiator_tag, radiator_tag];
+                radiator_velocities=ComplexF64[1, 0.5],
+            )
+            candidate = candidates[1]
+
+            # Both sides are CPU double and differ only in elimination order.
+            @test relative_error(reference.fem_pressure, candidate.fem_pressure) < 1e-9
+            @test relative_error(reference.bem_pressure, candidate.bem_pressure) < 1e-9
+            @test relative_error(reference.interface_flux, candidate.interface_flux) < 1e-9
+            @test relative_error(reference.bem_neumann, candidate.bem_neumann) < 1e-9
+            @test candidate.fem_interior_residual < 1e-10
+            @test isnothing(candidate.relative_residual)
+            @test candidate.pressure_continuity_error < 1e-8
+            @test candidate.flux_conservation_error < 1e-10
+            @test relative_error(0.5 .* candidate.bem_pressure, candidates[2].bem_pressure) < 1e-9
+            @test candidates[2].fem_interior_residual < 1e-10
+
+            condensed32 = condensed_system_at(Float32, 500.0)
+            try
+                @test eltype(condensed32.condensation.schur) == ComplexF32
+                # The interior factorization stays double whatever T is.
+                @test eltype(condensed32.condensation.interior_system) == ComplexF64
+                solution32 = solve_condensed_coupled_system(
+                    condensed32,
+                    physical_tag(fem_mesh32, 2, "Radiator"),
+                )
+                @test relative_error(candidate.fem_pressure, solution32.fem_pressure) < 1e-4
+                @test relative_error(candidate.bem_pressure, solution32.bem_pressure) < 1e-4
+                @test relative_error(candidate.interface_flux, solution32.interface_flux) < 1e-4
+                @test solution32.fem_interior_residual < 1e-5
+            finally
+                release_condensed_coupled_system!(condensed32)
+            end
+        finally
+            release_coupled_system!(monolithic)
+            release_condensed_coupled_system!(condensed)
+        end
+
+        # Γ is `interface ∪ transducer_fem_vertices`, so a transducer widens the retained set
+        # and exercises the retained-vertex slicing of the transducer blocks.
+        transducer = ElectrodynamicTransducer{Float64}(
+            "component:test",
+            [radiator_tag],
+            [1.0],
+            [1],
+            [-1.0],
+            SVector(0.0, 0.0, 1.0),
+            2.0,
+            1,
+            6.0,
+            0.0005,
+            7.0,
+            0.015,
+            0.0005,
+            1.0,
+        )
+        transducer_monolithic = monolithic_system(Float64, 500.0; transducers=[transducer])
+        transducer_condensed = condensed_system_at(Float64, 500.0; transducers=[transducer])
+        try
+            @test transducer_condensed.condensation.retained_count >
+                  length(interface_map.fem_vertex_indices)
+            @test transducer_condensed.solved_system_order < transducer_condensed.full_system_order
+            voltage = (
+                kind=:voltage,
+                radiator_tag=0,
+                transducer_index=1,
+                amplitude=ComplexF64(1, 0),
+            )
+            transducer_reference = only(solve_coupled_excitations(transducer_monolithic, [voltage]))
+            transducer_candidate = only(
+                solve_condensed_coupled_excitations(transducer_condensed, [voltage]),
+            )
+            @test relative_error(
+                transducer_reference.fem_pressure,
+                transducer_candidate.fem_pressure,
+            ) < 1e-9
+            @test relative_error(
+                transducer_reference.bem_pressure,
+                transducer_candidate.bem_pressure,
+            ) < 1e-9
+            @test relative_error(
+                transducer_reference.diaphragm_velocity,
+                transducer_candidate.diaphragm_velocity,
+            ) < 1e-9
+            @test relative_error(
+                transducer_reference.voice_coil_current,
+                transducer_candidate.voice_coil_current,
+            ) < 1e-9
+            @test transducer_candidate.fem_interior_residual < 1e-10
+
+            # Γ is built from the interface map and transducer surfaces only, neither of which
+            # depends on symmetry — symmetry enters only the BEM operators — so the retained set,
+            # and with it the condensation, is invariant under :x and :xy.
+            transducer_fem_vertices = unique(
+                findnz(
+                    assemble_transducer_operators(fem_mesh, bem_mesh, [transducer]).fem_surface,
+                )[1],
+            )
+            @test transducer_condensed.retained_fem_vertices ==
+                  sort(unique(vcat(interface_map.fem_vertex_indices, transducer_fem_vertices)))
+            @test transducer_condensed.retained_fem_vertices ==
+                  transducer_monolithic.retained_fem_vertices
+        finally
+            release_coupled_system!(transducer_monolithic)
+            release_condensed_coupled_system!(transducer_condensed)
+        end
+    end
+
+    @testset "Condensed coupled solver interior resonance" begin
+        sound_speed = 343.0
+        fem_mesh = load_gmsh41_volume(joinpath(CONDENSED_FIXTURE_ROOT, "femvolume.msh"), 0.001)
+        bem_mesh = load_gmsh22_with_tags(joinpath(CONDENSED_FIXTURE_ROOT, "exterior_conforming.msh"), 0.001)
+        interface_map = build_conforming_interface_map(
+            fem_mesh,
+            bem_mesh,
+            physical_tag(fem_mesh, 2, "Interface"),
+            2,
+        )
+        radiator_tag = physical_tag(fem_mesh, 2, "Radiator")
+        fem_mesh32 = load_gmsh41_volume(joinpath(CONDENSED_FIXTURE_ROOT, "femvolume.msh"), Float32(0.001))
+        bem_mesh32 = load_gmsh22_with_tags(
+            joinpath(CONDENSED_FIXTURE_ROOT, "exterior_conforming.msh"),
+            Float32(0.001),
+        )
+        interface_map32 = build_conforming_interface_map(
+            fem_mesh32,
+            bem_mesh32,
+            physical_tag(fem_mesh32, 2, "Interface"),
+            2,
+        )
+
+        # The Schur complement has poles at the eigenvalues of A_II. Restricting the FEM operator
+        # to interior rows *and* columns imposes u_Γ = 0, so these are the cavity modes with a
+        # pressure-release interface — a different, lower set than the rigid-wall modes
+        # `sealed_cavity_modes` reports.
+        retained = sort(unique(interface_map.fem_vertex_indices))
+        interior = setdiff(1:length(fem_mesh.vertices), retained)
+        stiffness, mass = assemble_p1_fem_matrices(fem_mesh)
+        interior_eigenvalues = eigen(
+            Symmetric(Matrix(stiffness[interior, interior])),
+            Symmetric(Matrix(mass[interior, interior])),
+        ).values
+        scale = maximum(abs, interior_eigenvalues)
+        positive = filter(value -> value > 1e-8 * scale, sort(real.(interior_eigenvalues)))
+        pole_hz = sound_speed * sqrt(first(positive)) / (2pi)
+        @test pole_hz > 0
+        @test pole_hz < first(sealed_cavity_modes(fem_mesh, sound_speed; count=1))
+
+        function resonance_solution(::Type{T}, frequency, bulk_loss) where {T}
+            mesh, boundary, mapping = T === Float32 ?
+                                      (fem_mesh32, bem_mesh32, interface_map32) :
+                                      (fem_mesh, bem_mesh, interface_map)
+            system = build_condensed_coupled_system(
+                mesh,
+                boundary,
+                mapping,
+                T(frequency),
+                T(sound_speed),
+                T(1.21);
+                quadrature_order=CONDENSED_QUADRATURE_ORDER,
+                singular_order=CONDENSED_SINGULAR_ORDER,
+                bulk_loss_factor=T(bulk_loss),
+            )
+            try
+                return solve_condensed_coupled_system(
+                    system,
+                    T === Float32 ? physical_tag(fem_mesh32, 2, "Radiator") : radiator_tag,
+                )
+            finally
+                release_condensed_coupled_system!(system)
+            end
+        end
+
+        function monolithic_solution(frequency, bulk_loss)
+            system = build_coupled_system(
+                fem_mesh,
+                bem_mesh,
+                interface_map,
+                frequency,
+                sound_speed,
+                1.21;
+                quadrature_order=CONDENSED_QUADRATURE_ORDER,
+                singular_order=CONDENSED_SINGULAR_ORDER,
+                validation_diagnostics=false,
+                bem_backend=:cpu,
+                bulk_loss_factor=bulk_loss,
+            )
+            try
+                return solve_coupled_system(system, radiator_tag)
+            finally
+                release_coupled_system!(system)
+            end
+        end
+
+        relative_error(reference, candidate) = norm(
+            ComplexF64.(candidate) .- ComplexF64.(reference),
+        ) / norm(ComplexF64.(reference))
+
+        for bulk_loss in (0.0, 0.02)
+            observed = NamedTuple[]
+            for offset in (-0.005, 0.0, 0.005)
+                frequency = pole_hz * (1 + offset)
+                reference = monolithic_solution(frequency, bulk_loss)
+                candidate = resonance_solution(Float64, frequency, bulk_loss)
+                candidate32 = resonance_solution(Float32, frequency, bulk_loss)
+                error64 = relative_error(reference.fem_pressure, candidate.fem_pressure)
+                error32 = relative_error(reference.fem_pressure, candidate32.fem_pressure)
+                push!(
+                    observed,
+                    (
+                        offset=offset,
+                        frequency_hz=frequency,
+                        error64=error64,
+                        error32=error32,
+                        residual64=candidate.fem_interior_residual,
+                        residual32=candidate32.fem_interior_residual,
+                    ),
+                )
+
+                # The interior residual only validates the back-substitution, so it stays small
+                # even where the Schur complement is badly conditioned. It is not a resonance
+                # detector — hence the separate accuracy assertions.
+                @test candidate.fem_interior_residual < 1e-10
+                @test candidate32.fem_interior_residual < 1e-4
+                @test all(isfinite, real.(candidate.fem_pressure))
+                @test all(isfinite, real.(candidate32.fem_pressure))
+
+                if offset == 0.0 && bulk_loss == 0.0
+                    # Straddling the pole with no loss is where condensation is weakest and the
+                    # tight tolerance genuinely does not hold. Assert only that it degrades
+                    # gracefully rather than diverging; the measured value is reported below as
+                    # the documented limit rather than pinned here.
+                    @test error64 < 1e-1
+                    @test error32 < 1e-1
+                else
+                    @test error64 < 1e-9
+                    @test error32 < 1e-3
+                end
+            end
+            @info "Schur condensation interior-resonance sweep" bulk_loss pole_hz observed
+        end
+    end
+else
+    @info "Set BLAB_RUN_COUPLED_REFERENCE=1 to run the condensed coupled solver validation."
+end
+
+@testset "Condensed regular assembly matches the shared CPU assembly" begin
+    # The condensed solver runs its own fork of the CPU regular assembly so it can be optimised
+    # without touching the path every other backend shares. This is the contract that makes that
+    # safe: bitwise-identical operators, across every symmetry mode, cached and uncached. Any
+    # optimisation added to the fork has to keep this passing.
+    rule = triangle_rule(Float32, 2)
+    k = Float32(2pi * 1000.0 / 343.0)
+    # Each symmetry mode needs a mesh that actually lies in its fundamental domain: the half mesh
+    # straddles y<0 so :xy rejects it. :xy matters most here -- it is four image sweeps, which is
+    # where a fused assembly has the most to gain and the most to get wrong.
+    for (symmetry, mesh_name) in ((:off, "sample.msh"), (:x, "sample_half.msh"), (:xy, "sample_quarter.msh"))
+        mesh = load_gmsh22_with_tags(
+            joinpath(@__DIR__, "..", "test_meshes", mesh_name), Float32(0.001),
+        )
+        p1 = build_p1_space(mesh)
+        dp0 = build_dp0_space(mesh)
+        element_indices = 1:min(24, length(mesh.faces))
+        singular_cache = build_singular_correction_cache(mesh, 2, element_indices)
+        symmetry == :off || validate_symmetry_fundamental_domain!(mesh, symmetry)
+        shared = assemble_regular_galerkin_operators(
+            mesh, p1, dp0, k, rule;
+            skip_singular=false, singular_order=2, element_indices=element_indices,
+            backend=:cpu, singular_cache=singular_cache, symmetry_mode=symmetry,
+        )
+        forked = BeatEngineCoupledCondensed.assemble_condensed_regular_operators(
+            mesh, p1, dp0, k, rule;
+            skip_singular=false, singular_order=2, element_indices=element_indices,
+            singular_cache=singular_cache, symmetry_mode=symmetry,
+        )
+        # With no images the fused sweep reduces to the base sweep, so it must be bitwise
+        # identical. With images it sums each pair's contributions before scattering instead of
+        # depositing them across four separate passes, which reorders the floating-point
+        # summation -- equal to round-off, not bit for bit. Both halves are asserted so a
+        # regression cannot hide behind the looser bound.
+        for op in (:single_layer, :double_layer, :adjoint_double_layer, :hypersingular)
+            if symmetry == :off
+                @test getproperty(forked, op) == getproperty(shared, op)
+            else
+                @test getproperty(forked, op) ≈ getproperty(shared, op) rtol = 1.0f-5
+            end
+        end
+        for count in (:regular_pairs, :singular_pairs, :skipped_pairs, :image_singular_pairs)
+            @test getproperty(forked, count) == getproperty(shared, count)
+        end
+
+        # Again through a prebuilt cache, which is how the solver actually calls it.
+        cache = build_beat_cpu_assembly_cache(
+            mesh, p1, dp0, rule;
+            singular_order=2, element_indices=element_indices, symmetry_mode=symmetry,
+        )
+        shared_cached = assemble_regular_galerkin_operators(
+            mesh, p1, dp0, k, rule;
+            skip_singular=false, singular_order=2, backend=:cpu,
+            singular_cache=singular_cache, cpu_cache=cache, symmetry_mode=symmetry,
+        )
+        forked_cached = BeatEngineCoupledCondensed.assemble_condensed_regular_operators(
+            mesh, p1, dp0, k, rule;
+            skip_singular=false, singular_order=2,
+            singular_cache=singular_cache, cpu_cache=cache, symmetry_mode=symmetry,
+        )
+        for op in (:single_layer, :double_layer, :adjoint_double_layer, :hypersingular)
+            if symmetry == :off
+                @test getproperty(forked_cached, op) == getproperty(shared_cached, op)
+            else
+                @test getproperty(forked_cached, op) ≈ getproperty(shared_cached, op) rtol = 1.0f-5
+            end
+        end
+        # The cached and uncached fused paths must agree with each other exactly: same order, same
+        # data, only the provenance of the reflected element sets differs.
+        for op in (:single_layer, :double_layer, :adjoint_double_layer, :hypersingular)
+            @test getproperty(forked_cached, op) == getproperty(forked, op)
+        end
+    end
+
+    # The fork keeps the strict stale-cache guard: a value-equal but distinct rule is rejected.
+    guard_mesh = load_gmsh22_with_tags(
+        joinpath(@__DIR__, "..", "test_meshes", "sample.msh"), Float32(0.001),
+    )
+    guard_p1 = build_p1_space(guard_mesh)
+    guard_dp0 = build_dp0_space(guard_mesh)
+    guard_indices = 1:min(24, length(guard_mesh.faces))
+    guard_cache = build_beat_cpu_assembly_cache(
+        guard_mesh, guard_p1, guard_dp0, rule;
+        singular_order=2, element_indices=guard_indices, symmetry_mode=:off,
+    )
+    @test_throws "cache quadrature rule does not match" BeatEngineCoupledCondensed.assemble_condensed_regular_operators(
+        guard_mesh, guard_p1, guard_dp0, k, triangle_rule(Float32, 2);
+        skip_singular=false, singular_order=2,
+        singular_cache=build_singular_correction_cache(guard_mesh, 2, guard_indices),
+        cpu_cache=guard_cache, symmetry_mode=:off,
+    )
+end
+
+@testset "Wavelength quadrature selection" begin
+    # h = sqrt(area) = 0.01 m exactly, so kh = 2*pi*f/c * 0.01 and a frequency can be placed
+    # either side of a cutoff by hand.
+    areas = fill(1.0e-4, 16)
+    c = 343.0
+    kh(f) = 2pi * f / c * 0.01
+    low, high = 2000.0, 20000.0
+    @test kh(low) < 2.0 && kh(high) > 2.0
+
+    below = wavelength_quadrature_order(areas, low, c, 4)
+    above = wavelength_quadrature_order(areas, high, c, 4)
+    @test below.order == 2
+    @test above.order == 4
+    @test above.base_order == 4
+    @test below.length ≈ 0.01
+    @test below.kh ≈ kh(low)
+    @test below.q1_max == 0.0 && below.q2_max == 2.0
+
+    # The one-point tier is unreachable at the shipped cutoff and reachable once it is raised.
+    @test wavelength_quadrature_order(areas, low, c, 4; q1_max=0.0).order == 2
+    @test wavelength_quadrature_order(areas, low, c, 4; q1_max=kh(low) + 0.1).order == 1
+
+    spread = [1.0e-4, 4.0e-4, 9.0e-4, 1.6e-3]
+    stats = [wavelength_quadrature_order(spread, low, c, 4; mesh_stat=s).area
+             for s in ("median", "p75", "p90", "max")]
+    @test issorted(stats)
+    @test stats[end] == maximum(spread)
+
+    @test_throws "Unsupported wavelength mesh stat" wavelength_quadrature_order(
+        areas, low, c, 4; mesh_stat="p50",
+    )
+    @test_throws "must be non-negative" wavelength_quadrature_order(
+        areas, low, c, 4; q1_max=-1.0,
+    )
+    @test_throws "must exceed" wavelength_quadrature_order(
+        areas, low, c, 4; q1_max=3.0, q2_max=2.0,
+    )
+    @test_throws "empty mesh" wavelength_quadrature_order(Float64[], low, c, 4)
+end
+
+@testset "Condensed per-order quadrature bundles" begin
+    fem_mesh = load_gmsh41_volume(joinpath(CONDENSED_FIXTURE_ROOT, "femvolume.msh"), 0.001)
+    bem_mesh = load_gmsh22_with_tags(joinpath(CONDENSED_FIXTURE_ROOT, "exterior_conforming.msh"), 0.001)
+    interface_map = build_conforming_interface_map(
+        fem_mesh, bem_mesh, physical_tag(fem_mesh, 2, "Interface"), 2,
+    )
+
+    cache = prepare_condensed_coupled_cache(
+        fem_mesh, bem_mesh, interface_map;
+        quadrature_order=2,
+        regular_quadrature_orders=[2, 4],
+        singular_order=CONDENSED_SINGULAR_ORDER,
+    )
+    @test sort(collect(keys(cache.quadrature_bundles))) == [2, 4]
+    @test cache.base_quadrature_order == 2
+    @test cache.singular_order == CONDENSED_SINGULAR_ORDER
+    # The base bundle reuses what the underlying coupled cache already built, so a single-order
+    # sweep is identical to using that cache directly.
+    @test cache.quadrature_bundles[2].rule === cache.base.rule
+    @test cache.quadrature_bundles[2].cpu_assembly_cache === cache.base.cpu_assembly_cache
+    for order in (2, 4)
+        bundle = cache.quadrature_bundles[order]
+        @test bundle.order == order
+        @test length(bundle.rule.points) == length(triangle_rule(Float64, order).points)
+        # The bundle owns its rule: the CPU assembly guard compares rules by pointer identity.
+        @test bundle.rule === bundle.cpu_assembly_cache.rule
+    end
+    # The base order is carried even when no frequency selects it: base 4 with every frequency
+    # picking 1 or 2 must not fail at cache setup.
+    absent_base = prepare_condensed_coupled_cache(
+        fem_mesh, bem_mesh, interface_map;
+        quadrature_order=4, regular_quadrature_orders=[1, 2],
+        singular_order=CONDENSED_SINGULAR_ORDER,
+    )
+    @test sort(collect(keys(absent_base.quadrature_bundles))) == [1, 2, 4]
+    @test absent_base.base_quadrature_order == 4
+    # A q1 bundle must NOT take its identity matrices from the 1-point rule: that rule integrates
+    # the P1xP1 mass matrix inexactly (area/9 uniform instead of area/6, area/12) and would
+    # silently degrade the Burton-Miller 0.5*I term. Clamped to order 2, so it matches exactly.
+    exact_p1_p1 = assemble_l2_identity_matrix(
+        bem_mesh, absent_base.base.p1, absent_base.base.dp0,
+        triangle_rule(Float64, 2), :p1, :p1,
+    )
+    wrong_p1_p1 = assemble_l2_identity_matrix(
+        bem_mesh, absent_base.base.p1, absent_base.base.dp0,
+        triangle_rule(Float64, 1), :p1, :p1,
+    )
+    @test absent_base.quadrature_bundles[1].identity_p1_p1 == exact_p1_p1
+    @test wrong_p1_p1 != exact_p1_p1          # the 1-point rule really is wrong here
+    # Clamping the identity rule must not disturb the regular rule, which stays at order 1.
+    @test length(absent_base.quadrature_bundles[1].rule.points) == 1
+    # Orders >= 2 are exact in exact arithmetic but not bitwise: different points and weights
+    # round differently, so they agree to round-off rather than identically.
+    @test absent_base.quadrature_bundles[4].identity_p1_p1 ≈ exact_p1_p1 rtol = 1e-13
+    @test absent_base.quadrature_bundles[4].identity_p1_p1 != exact_p1_p1
+    release_condensed_coupled_cache!(absent_base)
+
+    @test_throws "must be positive" prepare_condensed_coupled_cache(
+        fem_mesh, bem_mesh, interface_map;
+        quadrature_order=2, regular_quadrature_orders=[0], singular_order=CONDENSED_SINGULAR_ORDER,
+    )
+
+    # Stale-cache guards, compared as integers rather than as rules. Both fire before assembly.
+    for (order, singular, message) in (
+        (4, CONDENSED_SINGULAR_ORDER, "base quadrature order does not match"),
+        (2, CONDENSED_SINGULAR_ORDER + 1, "singular order does not match"),
+    )
+        @test_throws message build_condensed_coupled_system(
+            fem_mesh, bem_mesh, interface_map, 1000.0, 343.0, 1.2;
+            quadrature_order=order, singular_order=singular, cache=cache,
+        )
+    end
+    @test_throws "holds no quadrature bundle for order 3" build_condensed_coupled_system(
+        fem_mesh, bem_mesh, interface_map, 1000.0, 343.0, 1.2;
+        quadrature_order=2, regular_quadrature_order=3,
+        singular_order=CONDENSED_SINGULAR_ORDER, cache=cache,
+    )
+
+    # A multi-order cache must give each order exactly what a dedicated single-order cache gives.
+    # This is what catches a bundle being shared or looked up by the wrong key. The Schur solver
+    # never retains the assembled matrix, so the LU factors are the observable -- deterministic
+    # for identical input in one process, and order-sensitive through `bem_lhs`.
+    factors = Dict{Int,Any}()
+    for order in (2, 4)
+        dedicated = prepare_condensed_coupled_cache(
+            fem_mesh, bem_mesh, interface_map;
+            quadrature_order=order, singular_order=CONDENSED_SINGULAR_ORDER,
+        )
+        shared_system = build_condensed_coupled_system(
+            fem_mesh, bem_mesh, interface_map, 1000.0, 343.0, 1.2;
+            quadrature_order=2, regular_quadrature_order=order,
+            singular_order=CONDENSED_SINGULAR_ORDER, cache=cache,
+        )
+        dedicated_system = build_condensed_coupled_system(
+            fem_mesh, bem_mesh, interface_map, 1000.0, 343.0, 1.2;
+            quadrature_order=order, singular_order=CONDENSED_SINGULAR_ORDER, cache=dedicated,
+        )
+        @test shared_system.regular_quadrature_order == order
+        @test dedicated_system.regular_quadrature_order == order
+        @test shared_system.factorization.factors == dedicated_system.factorization.factors
+        factors[order] = copy(shared_system.factorization.factors)
+        release_condensed_coupled_system!(shared_system)
+        release_condensed_coupled_system!(dedicated_system)
+        release_condensed_coupled_cache!(dedicated)
+    end
+    # Changing order must actually change the operator, or the equality above holds trivially.
+    @test factors[2] != factors[4]
+
+    release_condensed_coupled_cache!(cache)
+end

--- a/src/blab/solvers/julia_local/tests/runtests.jl
+++ b/src/blab/solvers/julia_local/tests/runtests.jl
@@ -28,6 +28,7 @@ cuda_available() = CUDA_MODULE !== nothing && CUDA_MODULE.functional()
 end
 
 include(joinpath(@__DIR__, "coupled_solver_tests.jl"))
+include(joinpath(@__DIR__, "coupled_condensed_tests.jl"))
 
 @testset "cpu BLAS thread policy" begin
     @test beat_cpu_blas_thread_count(441; available_threads=16) == 1

--- a/src/blab/solvers/registry.py
+++ b/src/blab/solvers/registry.py
@@ -56,6 +56,23 @@ _BACKENDS: dict[str, SolverBackendInfo] = {
         factory=lambda **kwargs: _create_beat_engine_backend(beat_engine_backend="cpu", **kwargs),
         description="Run the local Boundary Element Acoustic Toolkit Engine CPU solver through the Boundary Lab subprocess adapter.",
     ),
+    "beat_cpu_condensed": SolverBackendInfo(
+        backend_id="beat_cpu_condensed",
+        label="BEAT Engine (CPU Condensed)",
+        capabilities=SolverCapabilities(
+            supports_remote_assets=False,
+            supports_parallel_workers=False,
+            supports_symmetry=True,
+            supports_channel_resynthesis=True,
+            is_remote=False,
+        ),
+        factory=lambda **kwargs: _create_beat_engine_backend(beat_engine_backend="cpu", **kwargs),
+        description=(
+            "Run the local Boundary Element Acoustic Toolkit Engine CPU solver with exact FEM interface "
+            "condensation, which eliminates the FEM interior onto the interface before the dense solve. "
+            "Identical to BEAT Engine (CPU) for exterior-only models, which have no FEM interior to eliminate."
+        ),
+    ),
     "beat_rocm": SolverBackendInfo(
         backend_id="beat_rocm",
         label="BEAT Engine (ROCm)",
@@ -81,6 +98,28 @@ _BACKENDS: dict[str, SolverBackendInfo] = {
         description="Run the bundled bempp-cl OpenCL CPU solver in the GUI process.",
     ),
 }
+
+
+#: Backends that can run compiled physical-system (exterior and coupled FEM-BEM) solves.
+PHYSICAL_SYSTEM_BACKEND_IDS = frozenset({"beat_cpu", "beat_cpu_condensed", "beat_cuda"})
+#: Backends that condense the FEM interior onto the interface for coupled solves.
+CONDENSING_BACKEND_IDS = frozenset({"beat_cpu_condensed", "beat_cuda"})
+
+
+def supports_physical_system_solves(backend_id: str) -> bool:
+    """Return whether a backend can run compiled physical-system solves."""
+
+    return normalize_backend_id(backend_id) in PHYSICAL_SYSTEM_BACKEND_IDS
+
+
+def backend_condenses_fem_interior(backend_id: str) -> bool:
+    """Return whether a backend uses FEM interface condensation for coupled solves.
+
+    Only meaningful for coupled FEM-BEM solves; exterior-only models have no FEM interior to
+    eliminate and run identically either way.
+    """
+
+    return normalize_backend_id(backend_id) in CONDENSING_BACKEND_IDS
 
 
 def available_backend_infos() -> tuple[SolverBackendInfo, ...]:
@@ -121,6 +160,7 @@ def normalize_backend_id(backend_id: str) -> str:
         "cuda": "beat_cuda",
         "beat_cpu": "beat_cpu",
         "cpu_beat": "beat_cpu",
+        "beat_cpu_condensed": "beat_cpu_condensed",
         "beat_rocm": "beat_rocm",
         "rocm": "beat_rocm",
         "amd": "beat_rocm",

--- a/src/blab/system_solve.py
+++ b/src/blab/system_solve.py
@@ -38,7 +38,11 @@ from blab.solve_results import (
     bem_boundary_result_domain,
     fem_volume_result_domain,
 )
-from blab.solvers.registry import normalize_backend_id
+from blab.solvers.registry import (
+    backend_condenses_fem_interior,
+    normalize_backend_id,
+    supports_physical_system_solves,
+)
 from blab.system_contract import OutputRequest, QuantityResult, SystemFrequencyResult, SystemSolveRequest
 
 
@@ -172,8 +176,11 @@ def prepare_system_ui_solve(
         component_names.append(component.name)
 
     normalized_backend_id = normalize_backend_id(backend_id)
-    if normalized_backend_id not in {"beat_cpu", "beat_cuda"}:
-        raise ValueError("Physical-system solves require BEAT Engine CPU or CUDA.")
+    if not supports_physical_system_solves(normalized_backend_id):
+        raise ValueError(
+            "Physical-system solves require BEAT Engine (CPU), BEAT Engine (CPU Condensed), "
+            "or BEAT Engine (CUDA) in Preferences."
+        )
     outputs = [
         OutputRequest(
             id="ui:exterior-pressure",
@@ -268,7 +275,9 @@ def prepare_system_ui_solve(
             "singular_order": 2 if is_coupled else 4,
             "validation_diagnostics": False,
             "cache_frequency_invariant": True,
-            "static_condensation": is_coupled and normalized_backend_id == "beat_cuda",
+            # Condensation is a property of the selected backend. Exterior-only models have no
+            # FEM interior, so it is off there regardless of which backend is chosen.
+            "static_condensation": is_coupled and backend_condenses_fem_interior(normalized_backend_id),
             "symmetry": symmetry,
         },
     )
@@ -300,7 +309,7 @@ def supports_exterior_system_protocol(
 ) -> bool:
     """Return whether an exterior project can use the local system worker."""
 
-    if stitch_exterior_meshes or normalize_backend_id(backend_id) not in {"beat_cpu", "beat_cuda"}:
+    if stitch_exterior_meshes or not supports_physical_system_solves(backend_id):
         return False
     try:
         if infer_physical_solve_kind(system) != PhysicalSolveKind.EXTERIOR_BEM:

--- a/tests/test_physical_compiler.py
+++ b/tests/test_physical_compiler.py
@@ -435,7 +435,7 @@ def test_coupled_backend_accepts_mmd_electrodynamic_component_and_voltage_port()
     assert "Linear single-axis rigid-body electrodynamic transducers with dry moving mass" in assumptions
 
 
-def test_coupled_cuda_rejects_static_condensation_with_full_matrix_diagnostics() -> None:
+def test_coupled_rejects_static_condensation_with_full_matrix_diagnostics() -> None:
     compiled = PhysicalSystemCompiler().compile(_fixture_system())
     request = SystemSolveRequest(
         compiled_system=compiled,
@@ -444,12 +444,13 @@ def test_coupled_cuda_rejects_static_condensation_with_full_matrix_diagnostics()
         solver_options={"static_condensation": True, "validation_diagnostics": True},
     )
 
+    # Both backends honour the condensation request, so the invalid combination is
+    # rejected regardless of where the BEM matrices are assembled.
     with pytest.raises(ValueError, match="static condensation cannot be combined"):
         CoupledProductionBackend(bem_backend="cuda").create_system_session(request)
 
-    cpu_session = CoupledProductionBackend(bem_backend="cpu").create_system_session(request)
-    assert cpu_session.request.solver_options["static_condensation"] is False
-    assert cpu_session.request.solver_options["validation_diagnostics"] is True
+    with pytest.raises(ValueError, match="static condensation cannot be combined"):
+        CoupledProductionBackend(bem_backend="cpu").create_system_session(request)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_physical_compiler.py
+++ b/tests/test_physical_compiler.py
@@ -423,6 +423,12 @@ def test_coupled_backend_accepts_mmd_electrodynamic_component_and_voltage_port()
     session = CoupledProductionBackend(bem_backend="cuda").create_system_session(request)
 
     assert session.request.solver_options["static_condensation"] is True
+    # The CPU backend honours the request instead of forcing condensation off.
+    cpu_session = CoupledProductionBackend(bem_backend="cpu").create_system_session(request)
+    assert cpu_session.request.solver_options["static_condensation"] is True
+    assert cpu_session.request.solver_options["bem_backend"] == "cpu"
+    cpu_default = CoupledProductionBackend(bem_backend="cpu").create_system_session(replace(request, solver_options={}))
+    assert "static_condensation" not in cpu_default.request.solver_options
     assert compiled.excitation_ports[0].kind == ExcitationPortKind.VOLTAGE
     assert DEFAULT_TRANSDUCER_REFERENCE_VOLTAGE_V == pytest.approx(2.83)
     assumptions = {item.statement for item in compiled.assumptions}
@@ -947,6 +953,88 @@ def test_coupled_electrodynamic_cuda_matches_cpu() -> None:
     assert cuda_result.diagnostics["formulation"] == "fem_interface_condensed"
     assert cuda_result.diagnostics["static_condensation_requested"] is True
     assert cuda_result.diagnostics["static_condensation_active"] is True
+
+
+@pytest.mark.skipif(
+    os.environ.get("BLAB_RUN_COUPLED_REFERENCE") != "1",
+    reason="Set BLAB_RUN_COUPLED_REFERENCE=1 to run CPU condensed/monolithic parity.",
+)
+def test_coupled_cpu_condensed_matches_cpu_monolithic() -> None:
+    """CPU condensed and monolithic solves agree through the real Julia backends."""
+
+    compiled = PhysicalSystemCompiler().compile(_bidirectional_electrodynamic_fixture_system())
+    outputs = (
+        OutputRequest(id="output:velocity", quantity="diaphragm_velocity"),
+        OutputRequest(id="output:current", quantity="voice_coil_current"),
+        OutputRequest(
+            id="output:field",
+            quantity="exterior_pressure",
+            options={"points_m": [[0.0, 0.0, 0.2]]},
+        ),
+    )
+    base_options = {
+        "quadrature_order": 1,
+        "singular_order": 1,
+        "validation_diagnostics": False,
+    }
+    monolithic_request = SystemSolveRequest(
+        compiled_system=compiled,
+        frequencies_hz=(500.0,),
+        excitation_port_ids=("excitation:radiator",),
+        outputs=outputs,
+        solver_options={**base_options, "static_condensation": False},
+    )
+    condensed_request = replace(
+        monolithic_request,
+        solver_options={**base_options, "static_condensation": True},
+    )
+    julia_executable = os.environ.get("BLAB_JULIA_EXE", "julia")
+    reference_backend = CoupledReferenceBackend(
+        julia_executable=julia_executable,
+        persistent_worker=False,
+    )
+    production_backend = CoupledProductionBackend(
+        bem_backend="cpu",
+        julia_executable=julia_executable,
+        persistent_worker=False,
+    )
+
+    (monolithic_result,) = tuple(reference_backend.create_system_session(monolithic_request).solve_stream())
+    (condensed_result,) = tuple(reference_backend.create_system_session(condensed_request).solve_stream())
+
+    monolithic_quantities = {quantity.id: quantity.values for quantity in monolithic_result.quantities}
+    condensed_quantities = {quantity.id: quantity.values for quantity in condensed_result.quantities}
+    for quantity_id, reference in monolithic_quantities.items():
+        scale = max(float(np.linalg.norm(reference)), np.finfo(float).eps)
+        relative_error = float(np.linalg.norm(condensed_quantities[quantity_id] - reference)) / scale
+        # Both sides are the FP64 reference backend and differ only in elimination order, so
+        # this is far tighter than the 5e-3 cross-backend tolerance.
+        assert relative_error < 1e-9, (quantity_id, relative_error)
+
+    # The shipping FP32 path only agrees to FP32 round-off: condensation factors the interior
+    # in ComplexF64 either way, so the condensed result is the more accurate of the two and
+    # the two FP32 runs are not expected to coincide beyond single precision.
+    (fp32_monolithic,) = tuple(production_backend.create_system_session(monolithic_request).solve_stream())
+    (fp32_condensed,) = tuple(production_backend.create_system_session(condensed_request).solve_stream())
+    fp32_reference = {quantity.id: quantity.values for quantity in fp32_monolithic.quantities}
+    fp32_candidate = {quantity.id: quantity.values for quantity in fp32_condensed.quantities}
+    for quantity_id, reference in fp32_reference.items():
+        scale = max(float(np.linalg.norm(reference)), np.finfo(float).eps)
+        relative_error = float(np.linalg.norm(fp32_candidate[quantity_id] - reference)) / scale
+        assert relative_error < 1e-4, (quantity_id, relative_error)
+    assert fp32_condensed.diagnostics["formulation"] == "fem_interface_condensed"
+    assert fp32_condensed.diagnostics["fem_interior_residual"] < 1e-4
+
+    assert monolithic_result.diagnostics["formulation"] == "monolithic"
+    assert condensed_result.diagnostics["formulation"] == "fem_interface_condensed"
+    assert condensed_result.diagnostics["linear_backend"] == "cpu"
+    assert condensed_result.diagnostics["linear_solver"] == "cpu_umfpack_schur_plus_dense_lu"
+    assert condensed_result.diagnostics["static_condensation_requested"] is True
+    assert condensed_result.diagnostics["static_condensation_active"] is True
+    assert condensed_result.diagnostics["solved_system_order"] < condensed_result.diagnostics["full_system_order"]
+    assert condensed_result.diagnostics["full_system_order"] == monolithic_result.diagnostics["full_system_order"]
+    assert condensed_result.diagnostics["fem_interior_residual"] < 1e-9
+    assert monolithic_result.diagnostics["fem_interior_residual"] is None
 
 
 @pytest.mark.skipif(

--- a/tests/test_solver_backends.py
+++ b/tests/test_solver_backends.py
@@ -27,10 +27,12 @@ from blab.solvers.http_server import (
 from blab.solvers.julia_local_backend import JuliaLocalBackend
 from blab.solvers.registry import (
     available_backend_infos,
+    backend_condenses_fem_interior,
     backend_info,
     backend_label_to_id,
     create_backend,
     normalize_backend_id,
+    supports_physical_system_solves,
 )
 
 
@@ -68,6 +70,26 @@ def test_solver_backend_registry_keeps_legacy_ids_available() -> None:
     assert "beat_cuda" in {info.backend_id for info in available_backend_infos()}
     assert "beat_cpu" in {info.backend_id for info in available_backend_infos()}
     assert "beat_rocm" in {info.backend_id for info in available_backend_infos()}
+
+
+def test_condensed_cpu_backend_is_selectable_and_maps_onto_the_cpu_engine() -> None:
+    labels = backend_label_to_id()
+
+    assert labels["BEAT Engine (CPU Condensed)"] == "beat_cpu_condensed"
+    assert "beat_cpu_condensed" in {info.backend_id for info in available_backend_infos()}
+    assert normalize_backend_id("beat_cpu_condensed") == "beat_cpu_condensed"
+    assert backend_info("beat_cpu_condensed").capabilities.supports_symmetry is True
+
+    assert backend_condenses_fem_interior("beat_cpu_condensed") is True
+    assert backend_condenses_fem_interior("beat_cuda") is True
+    assert backend_condenses_fem_interior("beat_cpu") is False
+
+    # All three BEAT physical-system backends are accepted; other engines are not.
+    assert supports_physical_system_solves("beat_cpu_condensed") is True
+    assert supports_physical_system_solves("beat_cpu") is True
+    assert supports_physical_system_solves("beat_cuda") is True
+    assert supports_physical_system_solves("beat_rocm") is False
+    assert supports_physical_system_solves("local") is False
 
 
 def test_local_backend_factory_exposes_contract_metadata() -> None:

--- a/tests/test_ui_system_config.py
+++ b/tests/test_ui_system_config.py
@@ -950,6 +950,34 @@ def test_coupled_ui_request_uses_excitation_basis_and_polar_field_points() -> No
     assert prepared.request.solver_options["cache_frequency_invariant"] is True
     assert prepared.request.solver_options["static_condensation"] is False
     assert prepared.request.solver_options["symmetry"] == "off"
+
+    # Condensation is selected by choosing the BEAT Engine (CPU Condensed) backend.
+    condensed = prepare_coupled_ui_solve(
+        system,
+        freq_min_hz=500.0,
+        freq_max_hz=1000.0,
+        freq_count=3,
+        observation_distance_m=2.0,
+        polar_angle_step_deg=90.0,
+        observation_planes=(new_observation_plane("Interior Slice"),),
+        backend_id="beat_cpu_condensed",
+    )
+    assert condensed.request.solver_options["static_condensation"] is True
+    assert condensed.backend_id == "beat_cpu_condensed"
+
+    # The CUDA backend always condenses coupled solves.
+    cuda_default = prepare_coupled_ui_solve(
+        system,
+        freq_min_hz=500.0,
+        freq_max_hz=1000.0,
+        freq_count=3,
+        observation_distance_m=2.0,
+        polar_angle_step_deg=90.0,
+        observation_planes=(new_observation_plane("Interior Slice"),),
+        backend_id="beat_cuda",
+    )
+    assert cuda_default.request.solver_options["static_condensation"] is True
+
     interior = next(
         region for region in prepared.request.compiled_system.regions if region.kind == AcousticRegionKind.BOUNDED_AIR
     )


### PR DESCRIPTION
New BEAT engine that applies FEM static condensation to coupled BEM-FEM CPU solves. This method is already in use on the CUDA pathway. All sample projects now solve with CPU only with under 16gb of RAM.

- New backend id 'beat_cpu_condensed' in solver registry
- Julia implementation: condensed interior assembly, UMFPACK Schur, dense LU coupled solve
- Env-gated parity test verified against monolithic solver, plus registry/UI gating tests

Benchmark:
<img width="1290" height="768" alt="IMG_6840" src="https://github.com/user-attachments/assets/a8642a19-3886-41ae-9a3d-c798de0a84b5" />
