### PR TITLE
Fix AttributeError that aborts every solve after the first

### DIFF
--- a/src/blab/ui/plots.py
+++ b/src/blab/ui/plots.py
@@ -282,6 +282,15 @@ class InteractivePlotCanvas(FigureCanvas):
         apply_figure_layout(self.figure, self._layout_profile)
         self._after_layout_profile_applied()
 
+    def _apply_layout(self) -> None:
+        """Re-apply the layout after an artist outside the axes comes or goes.
+
+        ``_remove_colorbar`` calls this on every canvas, so the base class has to
+        answer it. ``SpinoramaCanvas`` overrides it to also re-anchor its
+        right-hand DI axis; nothing else needs more than the layout profile.
+        """
+        self._apply_layout_profile()
+
     def _after_layout_profile_applied(self) -> None:
         """Reposition manually managed artists after the axes rectangle changes."""
 

--- a/tests/test_ui_plot_streaming_performance.py
+++ b/tests/test_ui_plot_streaming_performance.py
@@ -166,6 +166,26 @@ def test_isobar_canvas_reuses_mesh_colorbar_and_colormap() -> None:
     assert canvas._colormap is first_colormap
 
 
+def test_clearing_a_colorbar_canvas_does_not_need_a_spinorama_layout_hook() -> None:
+    """``_draw_empty`` runs on every canvas at the start of every solve.
+
+    It reaches ``_remove_colorbar``, which asks the canvas to re-apply its
+    layout. Only ``SpinoramaCanvas`` defined that hook, so a second solve died
+    here on an isobar plot before the solver was ever invoked.
+    """
+    canvas = IsobarCanvas("Horizontal")
+    freqs = np.asarray([100.0, 1000.0, 10000.0], dtype=np.float32)
+    angles = np.asarray([-90.0, 0.0, 90.0], dtype=np.float32)
+    values = np.arange(9, dtype=np.float32).reshape(3, 3) - 8.0
+
+    canvas.update_plot(freqs, angles, values, -30.0, 0.0, shading="nearest")
+    assert canvas._colorbar is not None
+
+    canvas._draw_empty()
+
+    assert canvas._colorbar is None
+
+
 def test_line_plot_canvases_reuse_existing_artists() -> None:
     freqs = np.asarray([100.0, 1000.0, 10000.0], dtype=np.float32)
 


### PR DESCRIPTION
## Problem

After a solve has drawn an isobar plot, every subsequent solve silently does
nothing. The GUI looks idle; a traceback goes to stdout only.

## Cause

`clear_plots()` runs at the start of every solve and calls `_draw_empty()` on
each plot widget. `InteractivePlotCanvas._draw_empty()` reaches
`_remove_colorbar()`, which ends with `self._apply_layout()` (`plots.py:831`).

`_apply_layout` is only defined on `SpinoramaCanvas` (`plots.py:1927`). The base
class defines `_apply_layout_profile()`. So the call raises `AttributeError` on
any other canvas that owns a colorbar — `IsobarCanvas` in particular — and the
solve is aborted before the solver is ever invoked.

```
  File "src/blab/ui/plots.py", line 831, in _remove_colorbar
    self._apply_layout()
AttributeError: 'IsobarCanvas' object has no attribute '_apply_layout'
```

## Fix

Give `InteractivePlotCanvas` a base-class `_apply_layout()` that applies the
layout profile. `SpinoramaCanvas` keeps its override, which additionally
re-anchors the right-hand DI axis.

## Reproducing

Run any solve that populates an isobar plot, then start a second solve. On
`dev` the second one never reaches the solver; with this change it runs.

## Test

`test_clearing_a_colorbar_canvas_does_not_need_a_spinorama_layout_hook` in
`tests/test_ui_plot_streaming_performance.py` drives a real `IsobarCanvas`
headlessly: `update_plot` to create the colorbar, then `_draw_empty()`. It
fails with the exact `AttributeError` above on `dev` and passes with the fix.

Full `pytest` suite and `ruff check` pass locally (Python 3.11, Linux,
`QT_QPA_PLATFORM=offscreen`).
