### PR TITLE
RFC: flag-gated fused CUDA Burton-Miller assembly and unified memory

### DIFF
--- a/src/blab/solvers/julia_local/coupled_solver.jl
+++ b/src/blab/solvers/julia_local/coupled_solver.jl
@@ -562,7 +562,11 @@ function solve_exterior_request(request, system, unbounded_region; event_mode=fa
                 )
             end : nothing
             assembly_started = time_ns()
-            operators = assemble_regular_galerkin_operators(
+            # PROTOTYPE: route the CUDA exterior solve through the fused direct
+            # Burton-Miller assembly (2 p1xp1 matrices) instead of materialising
+            # all eight operator matrices. Gated for A/B comparison.
+            direct_cuda_bm = backend == :cuda && get(ENV, "BLAB_DIRECT_BM", "0") == "1"
+            operators = direct_cuda_bm ? nothing : assemble_regular_galerkin_operators(
                 mesh,
                 p1_space,
                 dp0_space,
@@ -589,11 +593,32 @@ function solve_exterior_request(request, system, unbounded_region; event_mode=fa
             neumann_values = Vector{Vector{Complex{FloatType}}}()
             for excitation in excitations
                 neumann = exterior_neumann(mesh, excitation, density, omega)
-                pressure = backend == :cpu ?
-                           solve_burton_miller_neumann_cpu_system(cpu_system, neumann, FloatType) :
-                           solve_burton_miller_neumann(
-                    operators, device_identity_cache, neumann, wavenumber,
-                )
+                pressure = if direct_cuda_bm
+                    cuda_mod = BeatEngineCore.cuda_module()
+                    d_q = cuda_mod.CuArray(Complex{FloatType}.(neumann))
+                    direct_system = assemble_burton_miller_neumann_system_cuda(
+                        mesh,
+                        p1_space,
+                        dp0_space,
+                        d_q,
+                        wavenumber,
+                        rule;
+                        device_cache=device_cache,
+                        singular_cache=singular_cache,
+                        device_singular_cache=device_singular_cache,
+                        device_image_singular_cache=device_image_singular_cache,
+                        symmetry_mode=symmetry_mode,
+                    )
+                    solved = solve_burton_miller_system_cuda!(direct_system; return_gpu=false)
+                    cuda_mod.unsafe_free!(d_q)
+                    solved
+                elseif backend == :cpu
+                    solve_burton_miller_neumann_cpu_system(cpu_system, neumann, FloatType)
+                else
+                    solve_burton_miller_neumann(
+                        operators, device_identity_cache, neumann, wavenumber,
+                    )
+                end
                 push!(pressures, Complex{FloatType}.(pressure))
                 push!(neumann_values, neumann)
             end

--- a/src/blab/solvers/julia_local/src/BeatEngineCudaBurtonMiller.jl
+++ b/src/blab/solvers/julia_local/src/BeatEngineCudaBurtonMiller.jl
@@ -364,8 +364,16 @@ function assemble_burton_miller_neumann_system_cuda(
         error("Direct Burton-Miller image-near correction requires a matching device cache.")
     end
     p1_count = p1_space.global_dof_count
-    matrix_re = CUDA.zeros(T, p1_count, p1_count)
-    matrix_im = CUDA.zeros(T, p1_count, p1_count)
+    # PROTOTYPE: with BLAB_UNIFIED_MEM=1 the two system matrices (and the complex
+    # matrix broadcast from them) are allocated as CUDA unified memory, so the
+    # driver may oversubscribe VRAM and page to host RAM. Trades speed for capacity.
+    _bm_unified = get(ENV, "BLAB_UNIFIED_MEM", "0") == "1"
+    _bm_zeros(dims...) =
+        _bm_unified ?
+        fill!(CUDA.CuArray{T,length(dims),CUDA.UnifiedMemory}(undef, dims...), zero(T)) :
+        CUDA.zeros(T, dims...)
+    matrix_re = _bm_zeros(p1_count, p1_count)
+    matrix_im = _bm_zeros(p1_count, p1_count)
     rhs_re = CUDA.zeros(T, p1_count)
     rhs_im = CUDA.zeros(T, p1_count)
     matrix = rhs = nothing


### PR DESCRIPTION
**Draft / RFC — not proposed for merge as written.** Both changes are behind
environment flags and default to the current behaviour. I am opening this to
share measurements and ask whether the direction is one you want before doing
the work to productionise it.

## Motivation

The CUDA exterior solve OOMs on meshes that the hardware could otherwise carry.
`solve_exterior_request` calls `assemble_regular_galerkin_operators`, which
materialises eight operator matrices and only then builds the Burton-Miller
system from them. `deploy_solver.jl:458` already uses
`assemble_burton_miller_neumann_system_cuda`, which scatters element-pair
contributions straight into the system matrix — the classic exterior path never
got the same treatment.

Stock-path memory (Float32; the real matrices *and* their complex copies via
`_complex_gpu_matrix`, `BeatEngineCudaOperators.jl:11`):

| Mesh | real parts | complex copies | total |
|---|---|---|---|
| 13,908 tri | 2.22 GiB | 2.22 GiB | 4.43 GiB |
| 27,006 tri | 8.31 GiB | 8.31 GiB | 16.61 GiB |
| 44,002 tri | 21.93 GiB | 21.93 GiB | 43.87 GiB |

Verified against a live OOM: `Memory pool usage: 16.641 GiB` on the
27,006-triangle mesh, matching the computed 16.61 GiB.

## Change 1 — `BLAB_DIRECT_BM=1`: route the CUDA exterior solve through the fused assembly

`coupled_solver.jl` — when the flag is set and the backend is `:cuda`, skip the
eight-operator assembly and call `assemble_burton_miller_neumann_system_cuda`
directly.

**Accuracy.** Same model, 41 frequencies 200 Hz–20 kHz, 2,855-point mesh,
exported Horizontal Polar traces compared angle by angle against the stock CPU
path:

- max deviation **≤ 0.27 dB below 10 kHz**
- 4.90 dB max overall, confined to the top octave at rear angles
- RMS 0.54 dB, mean bias −0.03 dB

**Known limitations of the prototype as written:**

- The fused call takes `q_neumann` as input, so it assembles **per excitation**.
  Single-source models are fine; multi-radiator models would re-assemble per
  excitation. A production version wants one matrix with multiple right-hand
  sides.
- Near-correction caches are passed as `nothing`, so models using close-pair
  correction would differ.
- CUDA only. There is no `_rocm` or `_cpu` equivalent, so those backends keep
  the old path.

## Change 2 — `BLAB_UNIFIED_MEM=1`: allocate the system matrices as unified memory

`BeatEngineCudaBurtonMiller.jl` — allocate the two system matrices as
`CuArray{T,N,CUDA.UnifiedMemory}` so the driver may oversubscribe VRAM and page
to host RAM.

**Capacity.** 44,002-triangle mesh, full 360°, no symmetry, 20 kHz at 8 elements
per wavelength — a mesh that OOMs three different ways on the stock path:

- completed 41 frequencies, no errors, **6 min 44 s**
- GPU utilisation ≥90% for 370 consecutive 1-second samples — compute-bound, not
  page-fault-bound
- peak GPU total 23,946 MiB; device-resident peak 11,604 MiB, remainder paged to
  host

**Cost when the mesh fits natively.** 27,006-triangle mesh, identical frequency
list:

| Config | Total |
|---|---|
| fused assembly only | 95.9 s |
| fused + unified memory | 100.5 s (**+4.8%**) |

Per-frequency spot readings drift within a run (1.62 → 1.69 s), so only totals
are comparable.

Requires `CONCURRENT_MANAGED_ACCESS`; the TITAN RTX used here reports `true`.

## Related, no patch offered

- The stock assembly doubles its own memory via `_complex_gpu_matrix`
  (`BeatEngineCudaOperators.jl:11`) — complex copies of all eight real matrices.
- The fused path does the same thing once:
  `matrix = complex.(matrix_re, matrix_im)`
  (`BeatEngineCudaBurtonMiller.jl:451`) materialises a third full p1×p1 array
  (3.68 GiB on the 44k mesh) while both sources are live. Eliminating it needs
  the atomic-add kernels to write into an interleaved complex matrix, and CUDA
  atomics do not work on `ComplexF32` — which is presumably why real and
  imaginary are separate in the first place.

## Test environment

Ubuntu 24.04, NVIDIA TITAN RTX (24 GB, driver 595.84), Julia 1.12.7, CUDA
runtime 13.3. Neither flag is exercised by CI — there is no CUDA runner — and
with both flags unset the code paths are byte-for-byte the current ones.

## Questions

1. Is a fused direct-assembly exterior path something you want in `dev` at all,
   or does the eight-operator assembly need to stay for reasons I have missed?
2. If yes, should it be a multi-RHS assembly from the start rather than the
   per-excitation shape here?
3. Is unified memory better as an env flag, a solver preference, or an automatic
   fallback when the estimated matrix size exceeds free VRAM?
